### PR TITLE
Add prepare script for publishing on NPM

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@giantmachines/redux-websocket",
-  "version": "0.0.21",
+  "version": "0.0.22",
   "description": "A redux middleware to handle websocket connections",
   "main": "dist/index.js",
   "directories": {
@@ -9,6 +9,8 @@
   "scripts": {
     "test": "mocha --compilers js:babel-core/register",
     "build": "rimraf dist/ && babel -d dist/ src/",
+    "prepare": "npm run build",
+    "prepublish": "npm run prepare",
     "flow": "flow; test $? -eq 0 -o $? -eq 2"
   },
   "repository": {


### PR DESCRIPTION
It appears your package isn't being built before it is published to NPM adding these prepublish/prepare scripts will make sure the package works when installed from NPM.

You will also need to run `npm publish` again after merging in these changes. I bumped the package version number for you already as well :)