### PR TITLE
Fix Incorrect Action Type in Docs for WEBSOCKET_MESSAGE

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ Dispatched from redux-websocket when the WebSocket `onmessage` callback is execu
 
 ```javascript
 {
-  type: WEBSOCKET_CLOSED,
+  type: WEBSOCKET_MESSAGE,
   payload: {
     timestamp: Date,
     event: Event,


### PR DESCRIPTION
Action type is called WEBSOCKET_MESSAGE, but doc example has it as
WEBSOCKET_CLOSED.

This change updates to align properly.