### PR TITLE
Remove mocha-phantomjs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4,12 +4,6 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
-    "abbrev": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
-      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
-      "dev": true
-    },
     "acorn": {
       "version": "5.7.3",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.3.tgz",
@@ -32,12 +26,6 @@
           "dev": true
         }
       }
-    },
-    "adm-zip": {
-      "version": "0.2.1",
-      "resolved": "http://registry.npmjs.org/adm-zip/-/adm-zip-0.2.1.tgz",
-      "integrity": "sha1-6AHO3rW9mk6Y1pnFwPQjnicx3L8=",
-      "dev": true
     },
     "ajv": {
       "version": "4.11.8",
@@ -137,20 +125,6 @@
       "dev": true,
       "optional": true
     },
-    "asn1": {
-      "version": "0.1.11",
-      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz",
-      "integrity": "sha1-VZvhg3bQik7E2+gId9J4GGObLfc=",
-      "dev": true,
-      "optional": true
-    },
-    "assert-plus": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz",
-      "integrity": "sha1-7nQAlBMALYTOxyGcasgRgS5yMWA=",
-      "dev": true,
-      "optional": true
-    },
     "assertion-error": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
@@ -162,13 +136,6 @@
       "resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
       "integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=",
       "dev": true
-    },
-    "async": {
-      "version": "0.9.2",
-      "resolved": "http://registry.npmjs.org/async/-/async-0.9.2.tgz",
-      "integrity": "sha1-rqdNXmHB+JlhO/ZL2mbUx48v0X0=",
-      "dev": true,
-      "optional": true
     },
     "async-each": {
       "version": "1.0.1",
@@ -182,13 +149,6 @@
       "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
       "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
       "dev": true
-    },
-    "aws-sign2": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz",
-      "integrity": "sha1-xXED96F/wDfwLXwuZLYC6iI/fWM=",
-      "dev": true,
-      "optional": true
     },
     "babel-cli": {
       "version": "6.26.0",
@@ -1009,15 +969,6 @@
       "dev": true,
       "optional": true
     },
-    "boom": {
-      "version": "0.4.2",
-      "resolved": "http://registry.npmjs.org/boom/-/boom-0.4.2.tgz",
-      "integrity": "sha1-emNune1O/O+xnO9JR6PGffrukRs=",
-      "dev": true,
-      "requires": {
-        "hoek": "0.9.x"
-      }
-    },
     "brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -1212,16 +1163,6 @@
         "object-visit": "^1.0.0"
       }
     },
-    "combined-stream": {
-      "version": "0.0.7",
-      "resolved": "http://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
-      "integrity": "sha1-ATfmV7qlp1QcV6w3rF/AfXO03B8=",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "delayed-stream": "0.0.5"
-      }
-    },
     "commander": {
       "version": "2.19.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.19.0.tgz",
@@ -1250,24 +1191,6 @@
         "inherits": "^2.0.3",
         "readable-stream": "^2.2.2",
         "typedarray": "^0.0.6"
-      }
-    },
-    "config-chain": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.12.tgz",
-      "integrity": "sha512-a1eOIcu8+7lUInge4Rpf/n4Krkf3Dd9lqhljRzII1/Zno/kRtUWnznPO3jOKBmTEktkt3fkxisUcivoj0ebzoA==",
-      "dev": true,
-      "requires": {
-        "ini": "^1.3.4",
-        "proto-list": "~1.2.1"
-      },
-      "dependencies": {
-        "ini": {
-          "version": "1.3.5",
-          "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
-          "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
-          "dev": true
-        }
       }
     },
     "contains-path": {
@@ -1302,23 +1225,6 @@
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
       "dev": true
-    },
-    "cryptiles": {
-      "version": "0.2.2",
-      "resolved": "http://registry.npmjs.org/cryptiles/-/cryptiles-0.2.2.tgz",
-      "integrity": "sha1-7ZH/HxetE9N0gohZT4pIoNJvMlw=",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "boom": "0.4.x"
-      }
-    },
-    "ctype": {
-      "version": "0.5.3",
-      "resolved": "http://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz",
-      "integrity": "sha1-gsGMJGH3QRTvFsE1IkrQuRRMoS8=",
-      "dev": true,
-      "optional": true
     },
     "d": {
       "version": "1.0.0",
@@ -1448,13 +1354,6 @@
         "pify": "^3.0.0",
         "rimraf": "^2.2.8"
       }
-    },
-    "delayed-stream": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz",
-      "integrity": "sha1-1LH0OpPoKW3+AmlPRoC8N6MTxz8=",
-      "dev": true,
-      "optional": true
     },
     "detect-indent": {
       "version": "4.0.0",
@@ -1953,24 +1852,6 @@
       "optional": true,
       "requires": {
         "for-in": "^1.0.1"
-      }
-    },
-    "forever-agent": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.5.2.tgz",
-      "integrity": "sha1-bQ4JxJIflKJ/Y9O0nF/v8epMUTA=",
-      "dev": true
-    },
-    "form-data": {
-      "version": "0.1.4",
-      "resolved": "http://registry.npmjs.org/form-data/-/form-data-0.1.4.tgz",
-      "integrity": "sha1-kavXiKupcCsaq/qLwBAxoqyeOxI=",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "async": "~0.9.0",
-        "combined-stream": "~0.0.4",
-        "mime": "~1.2.11"
       }
     },
     "formatio": {
@@ -2739,29 +2620,10 @@
         }
       }
     },
-    "hawk": {
-      "version": "1.0.0",
-      "resolved": "http://registry.npmjs.org/hawk/-/hawk-1.0.0.tgz",
-      "integrity": "sha1-uQuxaYByhUEdp//LjdJZhQLTtS0=",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "boom": "0.4.x",
-        "cryptiles": "0.2.x",
-        "hoek": "0.9.x",
-        "sntp": "0.2.x"
-      }
-    },
     "he": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
       "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
-      "dev": true
-    },
-    "hoek": {
-      "version": "0.9.1",
-      "resolved": "http://registry.npmjs.org/hoek/-/hoek-0.9.1.tgz",
-      "integrity": "sha1-PTIkYrrfB3Fup+uFuviAec3c5QU=",
       "dev": true
     },
     "home-or-tmp": {
@@ -2772,18 +2634,6 @@
       "requires": {
         "os-homedir": "^1.0.0",
         "os-tmpdir": "^1.0.1"
-      }
-    },
-    "http-signature": {
-      "version": "0.10.1",
-      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
-      "integrity": "sha1-T72sEyVZqoMjEh5UB3nAoBKyfmY=",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "asn1": "0.1.11",
-        "assert-plus": "^0.1.5",
-        "ctype": "0.5.3"
       }
     },
     "ignore": {
@@ -2812,12 +2662,6 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
       "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-      "dev": true
-    },
-    "ini": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/ini/-/ini-1.1.0.tgz",
-      "integrity": "sha1-ToCMLOFExsF4iRjgNNZ5e8bPYoE=",
       "dev": true
     },
     "inquirer": {
@@ -3209,12 +3053,6 @@
         "jsonify": "~0.0.0"
       }
     },
-    "json-stringify-safe": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
-      "dev": true
-    },
     "json5": {
       "version": "0.5.1",
       "resolved": "http://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
@@ -3237,12 +3075,6 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-1.4.1.tgz",
       "integrity": "sha1-OGchPo3Xm/Ho8jAMDPwe+xgsDfE=",
-      "dev": true
-    },
-    "kew": {
-      "version": "0.1.7",
-      "resolved": "http://registry.npmjs.org/kew/-/kew-0.1.7.tgz",
-      "integrity": "sha1-CjKoF/8amzsSuMm6z0vE1nmvjnI=",
       "dev": true
     },
     "kind-of": {
@@ -3345,12 +3177,6 @@
         "parse-glob": "^3.0.4",
         "regex-cache": "^0.4.2"
       }
-    },
-    "mime": {
-      "version": "1.2.11",
-      "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz",
-      "integrity": "sha1-WCA+7Ybjpe8XrtK32evUfwpg3RA=",
-      "dev": true
     },
     "minimatch": {
       "version": "3.0.4",
@@ -3456,23 +3282,6 @@
         }
       }
     },
-    "mocha-phantomjs": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/mocha-phantomjs/-/mocha-phantomjs-4.1.0.tgz",
-      "integrity": "sha1-x14WYS4aavCtjSgeOi/vSdVeUFs=",
-      "dev": true,
-      "requires": {
-        "commander": "^2.8.1",
-        "mocha-phantomjs-core": "^1.1.0",
-        "phantomjs": "1.9.7-15"
-      }
-    },
-    "mocha-phantomjs-core": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/mocha-phantomjs-core/-/mocha-phantomjs-core-1.3.1.tgz",
-      "integrity": "sha1-WGU4yNcfqN6QxBpGrMBIHB+4Phg=",
-      "dev": true
-    },
     "ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
@@ -3541,32 +3350,11 @@
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
       "dev": true
     },
-    "ncp": {
-      "version": "0.4.2",
-      "resolved": "http://registry.npmjs.org/ncp/-/ncp-0.4.2.tgz",
-      "integrity": "sha1-q8xsvT7C7Spyn/bnwfqPAXhKhXQ=",
-      "dev": true
-    },
     "next-tick": {
       "version": "1.0.0",
       "resolved": "http://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
       "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw=",
       "dev": true
-    },
-    "node-uuid": {
-      "version": "1.4.8",
-      "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.8.tgz",
-      "integrity": "sha1-sEDrCSOWivq/jTL7HxfxFn/auQc=",
-      "dev": true
-    },
-    "nopt": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/nopt/-/nopt-2.2.1.tgz",
-      "integrity": "sha1-KqCbfRdoSHs7ianFqlIzW/8Lrqc=",
-      "dev": true,
-      "requires": {
-        "abbrev": "1"
-      }
     },
     "normalize-path": {
       "version": "2.1.1",
@@ -3577,54 +3365,11 @@
         "remove-trailing-separator": "^1.0.1"
       }
     },
-    "npmconf": {
-      "version": "0.0.24",
-      "resolved": "https://registry.npmjs.org/npmconf/-/npmconf-0.0.24.tgz",
-      "integrity": "sha1-t4h1sIjMw8Cvo+zrPOMkSxtSOQw=",
-      "dev": true,
-      "requires": {
-        "config-chain": "~1.1.1",
-        "inherits": "~1.0.0",
-        "ini": "~1.1.0",
-        "mkdirp": "~0.3.3",
-        "nopt": "2",
-        "once": "~1.1.1",
-        "osenv": "0.0.3",
-        "semver": "~1.1.0"
-      },
-      "dependencies": {
-        "inherits": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/inherits/-/inherits-1.0.2.tgz",
-          "integrity": "sha1-ykMJ2t7mtUzAuNJH6NfHoJdb3Js=",
-          "dev": true
-        },
-        "mkdirp": {
-          "version": "0.3.5",
-          "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz",
-          "integrity": "sha1-3j5fiWHIjHh+4TaN+EmsRBPsqNc=",
-          "dev": true
-        },
-        "once": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/once/-/once-1.1.1.tgz",
-          "integrity": "sha1-nbV0kzzLCMOnYU0VQDLAnqbzOec=",
-          "dev": true
-        }
-      }
-    },
     "number-is-nan": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
       "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
       "dev": true
-    },
-    "oauth-sign": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.3.0.tgz",
-      "integrity": "sha1-y1QPk7srIqfVlBaRoojWDo6pOG4=",
-      "dev": true,
-      "optional": true
     },
     "object-assign": {
       "version": "4.1.1",
@@ -3764,12 +3509,6 @@
       "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
       "dev": true
     },
-    "osenv": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.0.3.tgz",
-      "integrity": "sha1-zWrY3bKQkVrZ4idlV2Al1BHynLY=",
-      "dev": true
-    },
     "output-file-sync": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/output-file-sync/-/output-file-sync-1.1.2.tgz",
@@ -3832,38 +3571,6 @@
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
       "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
       "dev": true
-    },
-    "phantomjs": {
-      "version": "1.9.7-15",
-      "resolved": "http://registry.npmjs.org/phantomjs/-/phantomjs-1.9.7-15.tgz",
-      "integrity": "sha1-Czp85jBIaoO+kf9Ogy7uIOlxEVs=",
-      "dev": true,
-      "requires": {
-        "adm-zip": "0.2.1",
-        "kew": "~0.1.7",
-        "mkdirp": "0.3.5",
-        "ncp": "0.4.2",
-        "npmconf": "0.0.24",
-        "progress": "^1.1.5",
-        "request": "2.36.0",
-        "request-progress": "^0.3.1",
-        "rimraf": "~2.2.2",
-        "which": "~1.0.5"
-      },
-      "dependencies": {
-        "mkdirp": {
-          "version": "0.3.5",
-          "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz",
-          "integrity": "sha1-3j5fiWHIjHh+4TaN+EmsRBPsqNc=",
-          "dev": true
-        },
-        "rimraf": {
-          "version": "2.2.8",
-          "resolved": "http://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
-          "integrity": "sha1-5Dm+Kq7jJzIZUnMPmaiSnk/FBYI=",
-          "dev": true
-        }
-      }
     },
     "pify": {
       "version": "3.0.0",
@@ -3946,32 +3653,6 @@
       "version": "1.1.8",
       "resolved": "http://registry.npmjs.org/progress/-/progress-1.1.8.tgz",
       "integrity": "sha1-4mDHj2Fhzdmw5WzD4Khd4Xx6V74=",
-      "dev": true
-    },
-    "proto-list": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
-      "integrity": "sha1-IS1b/hMYMGpCD2QCuOJv85ZHqEk=",
-      "dev": true
-    },
-    "psl": {
-      "version": "1.1.29",
-      "resolved": "https://registry.npmjs.org/psl/-/psl-1.1.29.tgz",
-      "integrity": "sha512-AeUmQ0oLN02flVHXWh9sSJF7mcdFq0ppid/JkErufc3hGIV/AMa8Fo9VgDo/cT2jFdOWoFvHp90qqBH54W+gjQ==",
-      "dev": true,
-      "optional": true
-    },
-    "punycode": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-      "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
-      "dev": true,
-      "optional": true
-    },
-    "qs": {
-      "version": "0.6.6",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-0.6.6.tgz",
-      "integrity": "sha1-bgFQmP9RlouKPIGQAdXyyJvEsQc=",
       "dev": true
     },
     "quibble": {
@@ -4481,35 +4162,6 @@
         "is-finite": "^1.0.0"
       }
     },
-    "request": {
-      "version": "2.36.0",
-      "resolved": "http://registry.npmjs.org/request/-/request-2.36.0.tgz",
-      "integrity": "sha1-KMbAQmLHuf/dIbklU3RRfubZQ/U=",
-      "dev": true,
-      "requires": {
-        "aws-sign2": "~0.5.0",
-        "forever-agent": "~0.5.0",
-        "form-data": "~0.1.0",
-        "hawk": "~1.0.0",
-        "http-signature": "~0.10.0",
-        "json-stringify-safe": "~5.0.0",
-        "mime": "~1.2.9",
-        "node-uuid": "~1.4.0",
-        "oauth-sign": "~0.3.0",
-        "qs": "~0.6.0",
-        "tough-cookie": ">=0.12.0",
-        "tunnel-agent": "~0.4.0"
-      }
-    },
-    "request-progress": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/request-progress/-/request-progress-0.3.1.tgz",
-      "integrity": "sha1-ByHBBdipasayzossia4tXs/Pazo=",
-      "dev": true,
-      "requires": {
-        "throttleit": "~0.0.2"
-      }
-    },
     "require-uncached": {
       "version": "1.0.3",
       "resolved": "http://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
@@ -4616,12 +4268,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/samsam/-/samsam-1.1.2.tgz",
       "integrity": "sha1-vsEf3IOp/aBjQBIQ5AF2wwJNFWc=",
-      "dev": true
-    },
-    "semver": {
-      "version": "1.1.4",
-      "resolved": "http://registry.npmjs.org/semver/-/semver-1.1.4.tgz",
-      "integrity": "sha1-LlpOcrqwNHLMl/cnU7RQiRLvVUA=",
       "dev": true
     },
     "set-value": {
@@ -4811,16 +4457,6 @@
       "optional": true,
       "requires": {
         "kind-of": "^3.2.0"
-      }
-    },
-    "sntp": {
-      "version": "0.2.4",
-      "resolved": "http://registry.npmjs.org/sntp/-/sntp-0.2.4.tgz",
-      "integrity": "sha1-+4hfGLDzqtGJ+CSGJTa87ux1CQA=",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "hoek": "0.9.x"
       }
     },
     "source-map": {
@@ -5028,12 +4664,6 @@
       "integrity": "sha512-KU3SA3TjRRM932jpNfD3u4Ec3bSvedyo5ITPI7zgWYnKep7BwQQaxlhI9qbO+lKJoRnoAbEVfMcAHRuKVYikDA==",
       "dev": true
     },
-    "throttleit": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/throttleit/-/throttleit-0.0.2.tgz",
-      "integrity": "sha1-z+34jmDADdlpe2H90qg0OptoDq8=",
-      "dev": true
-    },
     "through": {
       "version": "2.3.8",
       "resolved": "http://registry.npmjs.org/through/-/through-2.3.8.tgz",
@@ -5096,29 +4726,11 @@
         }
       }
     },
-    "tough-cookie": {
-      "version": "2.4.3",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
-      "integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "psl": "^1.1.24",
-        "punycode": "^1.4.1"
-      }
-    },
     "trim-right": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
       "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
       "dev": true
-    },
-    "tunnel-agent": {
-      "version": "0.4.3",
-      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
-      "integrity": "sha1-Y3PbdpCf5XDgjXNYM2Xtgop07us=",
-      "dev": true,
-      "optional": true
     },
     "type-check": {
       "version": "0.3.2",
@@ -5263,12 +4875,6 @@
       "requires": {
         "user-home": "^1.1.1"
       }
-    },
-    "which": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/which/-/which-1.0.9.tgz",
-      "integrity": "sha1-RgwdoPgQED0DIam2M6+eV15kSG8=",
-      "dev": true
     },
     "wordwrap": {
       "version": "1.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@giantmachines/redux-websocket",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@giantmachines/redux-websocket",
-  "version": "0.0.23",
+  "version": "0.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -42,7 +42,6 @@
     "expect": "1.20.2",
     "flow-bin": "0.36.0",
     "mocha": "5.2.0",
-    "mocha-phantomjs": "4.1.0",
     "redux": "3.6.0",
     "redux-mock-store": "1.2.1",
     "sinon": "1.17.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@giantmachines/redux-websocket",
-  "version": "0.0.23",
+  "version": "0.1.0",
   "description": "A redux middleware to handle websocket connections",
   "main": "dist/index.js",
   "directories": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@giantmachines/redux-websocket",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "A redux middleware to handle websocket connections",
   "main": "dist/index.js",
   "directories": {


### PR DESCRIPTION
We weren't using this package for anything, and it was surfacing alerts from `npm audit`.