### PR TITLE
Better error handling.

### DIFF
--- a/demo/src/app/Index.tsx
+++ b/demo/src/app/Index.tsx
@@ -37,6 +37,8 @@ const disconnectSimulatorMiddleware = () => {
     if (type === `${WEBSOCKET_PREFIX}::BROKEN`) {
       (window as any).WebSocket = class FakeWebSocket {
         close = () => {}
+
+        addEventListener = () => {}
       };
     }
 

--- a/src/ReduxWebSocket.ts
+++ b/src/ReduxWebSocket.ts
@@ -143,7 +143,7 @@ export default class ReduxWebSocket {
    */
   disconnect = () => {
     if (this.websocket) {
-      this.websocket.close();
+      this.websocket.close(1000, 'WebSocket connection closed by redux-websocket.');
 
       this.websocket = null;
     } else {

--- a/src/ReduxWebSocket.ts
+++ b/src/ReduxWebSocket.ts
@@ -128,7 +128,7 @@ export default class ReduxWebSocket {
       const { currentTarget } = event;
       const { url } = currentTarget as WebSocket;
 
-      dispatch(error(null, new Error(`\`redux-websocket\` erorr. Could not open WebSocket connection to "${url}".`), prefix));
+      dispatch(error(null, new Error(`\`redux-websocket\` error. Could not open WebSocket connection to "${url}".`), prefix));
     });
 
     this.websocket.addEventListener('open', (event) => {

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -53,7 +53,7 @@ export const message = (event: MessageEvent, prefix: string) => {
 };
 export const open = (event: Event, prefix: string) => buildAction(`${prefix}::${WEBSOCKET_OPEN}`, event);
 export const broken = (prefix: string) => buildAction(`${prefix}::${WEBSOCKET_BROKEN}`);
-export const error = (originalAction: Action, err: Error, prefix: string) => (
+export const error = (originalAction: Action | null, err: Error, prefix: string) => (
   buildAction(`${prefix}::${WEBSOCKET_ERROR}`, {
     message: err.message,
     name: err.name,

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -18,15 +18,17 @@ const mockStore = () => {
 };
 
 reduxWebSocketMock.mockImplementation(options => ({
+  close: () => {},
+  connect: connectMock,
+  disconnect: disconnectMock,
+  handleBrokenConnection: () => {},
+  hasOpened: false,
+  lastSocketUrl: '',
   options,
   reconnectCount: 0,
   reconnectionInterval: null,
-  lastSocketUrl: '',
-  handleBrokenConnection: () => {},
-  websocket: null,
-  connect: connectMock,
-  disconnect: disconnectMock,
   send: sendMock,
+  websocket: null,
 }));
 
 describe('middleware', () => {


### PR DESCRIPTION
Based on the issue #53, this handles errors a little better.

There is an issue where if the connection never opens, the WebSocket instance will still emit a `close` event. Currently, we immediately try and reconnect. In the case where you are trying to connect to a URL that is not valid, or cannot connect, we try and reconnect over and over again until we lock up the browser.

Now the middleware listens for the `error` event. It also keeps track of if the connection has ever opened before, and will only attempt to reconnect in that case.

Fixes #53.