### PR TITLE
Accept a protocols argument in the connect function.

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,11 +77,24 @@ These actions must be dispatched by you, however we do export action creator fun
 import { connect } from '@giantmachines/redux-websocket';
 
 store.dispatch(connect('wss://my-server.com'));
+
+// You can also provide protocols if needed.
+// See: https://developer.mozilla.org/en-US/docs/Web/API/WebSocket/WebSocket
+//
+// Note that this function only allows passing an array of protocols, even though
+// the spec allows passing a string or an array of strings. This is to support
+// the prefix argument, in the case that you've prefixed your action names.
+store.dispatch(connect('wss://my-server.com', ['v1.stream.example.com']));
+
+// ...other ways to call this function:
+store.dispatch(connect('wss://my-server.com', ['v1.stream.example.com'], 'MY_PREFIX'));
+store.dispatch(connect('wss://my-server.com', 'MY_PREFIX'));
 ```
 
 ###### Arguments:
 
 1. `url` *(`string`)*: WebSocket URL to connect to.
+2. \[`protocols`\] *(`string[]`)*: Optional sub-protocols.
 2. \[`prefix`\] *(`string`)*: Optional action type prefix.
 
 ---

--- a/src/ReduxWebSocket.ts
+++ b/src/ReduxWebSocket.ts
@@ -66,7 +66,9 @@ export default class ReduxWebSocket {
     const { prefix } = this.options;
 
     this.lastSocketUrl = payload.url;
-    this.websocket = new WebSocket(payload.url);
+    this.websocket = payload.protocols
+      ? new WebSocket(payload.url, payload.protocols)
+      : new WebSocket(payload.url);
 
     this.websocket.addEventListener('close', event => this.handleClose(dispatch, prefix, event));
     this.websocket.addEventListener('error', () => this.handleError(dispatch, prefix));

--- a/src/__tests__/actions.test.ts
+++ b/src/__tests__/actions.test.ts
@@ -32,6 +32,32 @@ describe('actions', () => {
           },
         });
       });
+
+      it('should return the correct action with protocols', () => {
+        const act = actions.connect('fake url', ['protocol']);
+
+        expect(act).toEqual({
+          type: `${actionTypes.DEFAULT_PREFIX}::${actionTypes.WEBSOCKET_CONNECT}`,
+          meta: { timestamp: expect.any(Date) },
+          payload: {
+            url: 'fake url',
+            protocols: ['protocol'],
+          },
+        });
+      });
+
+      it('should return the correct action with protocols and a user prefix', () => {
+        const act = actions.connect('fake url', ['protocol'], PREFIX);
+
+        expect(act).toEqual({
+          type: `${PREFIX}::${actionTypes.WEBSOCKET_CONNECT}`,
+          meta: { timestamp: expect.any(Date) },
+          payload: {
+            url: 'fake url',
+            protocols: ['protocol'],
+          },
+        });
+      });
     });
 
     describe('disconnect', () => {

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -14,6 +14,10 @@ import {
 } from './actionTypes';
 import { Action } from './types';
 
+type WithProtocols = [string[]] | [string[], string];
+type WithPrefix = [string];
+type ConnectRestArgs = [] | WithPrefix | WithProtocols;
+
 type BuiltAction<T> = {
   type: string,
   meta: {
@@ -21,6 +25,12 @@ type BuiltAction<T> = {
   },
   payload?: T,
 }
+
+/**
+ * Determine if the rest args to `connect` contains protocols or not.
+ * @private
+ */
+const isProtocols = (args: ConnectRestArgs): args is WithProtocols => Array.isArray(args[0]);
 
 /**
  * Create an FSA compliant action.
@@ -46,7 +56,25 @@ function buildAction<T>(actionType: string, payload?: T, meta?: any): BuiltActio
 
 // Action creators for user dispatched actions. These actions are all optionally
 // prefixed.
-export const connect = (url: string, prefix?: string) => buildAction(`${prefix || DEFAULT_PREFIX}::${WEBSOCKET_CONNECT}`, { url });
+export const connect = (url: string, ...args: ConnectRestArgs) => {
+  let prefix: string | undefined;
+  let protocols: string[] | undefined;
+
+  // If there's only one argument, check if it's protocols or a prefix.
+  if (args.length === 1) {
+    [protocols, prefix] = isProtocols(args) ? args : [undefined, args[0]];
+  }
+
+  // If there are two arguments after `url`, assume it's protocols and prefix.
+  if (args.length === 2) {
+    [protocols, prefix] = args;
+  }
+
+  return buildAction(
+    `${prefix || DEFAULT_PREFIX}::${WEBSOCKET_CONNECT}`,
+    { url, protocols },
+  );
+};
 export const disconnect = (prefix?: string) => buildAction(`${prefix || DEFAULT_PREFIX}::${WEBSOCKET_DISCONNECT}`);
 export const send = (msg: any, prefix?: string) => buildAction(`${prefix || DEFAULT_PREFIX}::${WEBSOCKET_SEND}`, msg);
 


### PR DESCRIPTION
Fixes #72.

This allows for calling `connect` with protocols in a backwards compatible way. See the README for further documentation on what's supported.