### PR TITLE
Added availability to send binary data over socket

### DIFF
--- a/src/ReduxWebSocket.ts
+++ b/src/ReduxWebSocket.ts
@@ -104,6 +104,13 @@ export default class ReduxWebSocket {
    */
   send = (_store: MiddlewareAPI, { payload }: Action) => {
     if (this.websocket) {
+      const isPayloadBinary = payload instanceof Buffer || payload instanceof ArrayBuffer;
+      if (isPayloadBinary && !this.websocket.binaryType) {
+        throw new Error(
+          'Attempted to send binary data but data type is set to String. Set binaryType inside onOpen method',
+        );
+      }
+
       if (this.websocket.binaryType) {
         this.websocket.send(payload);
       } else {

--- a/src/ReduxWebSocket.ts
+++ b/src/ReduxWebSocket.ts
@@ -104,7 +104,11 @@ export default class ReduxWebSocket {
    */
   send = (_store: MiddlewareAPI, { payload }: Action) => {
     if (this.websocket) {
-      this.websocket.send(JSON.stringify(payload));
+      if (this.websocket.binaryType) {
+        this.websocket.send(payload);
+      } else {
+        this.websocket.send(JSON.stringify(payload));
+      }
     } else {
       throw new Error(
         'Socket connection not initialized. Dispatch WEBSOCKET_CONNECT first',

--- a/src/ReduxWebSocket.ts
+++ b/src/ReduxWebSocket.ts
@@ -104,7 +104,7 @@ export default class ReduxWebSocket {
    */
   send = (_store: MiddlewareAPI, { payload }: Action) => {
     if (this.websocket) {
-      const isPayloadBinary = payload instanceof Buffer || payload instanceof ArrayBuffer;
+      const isPayloadBinary = payload instanceof Blob || payload instanceof ArrayBuffer;
       if (isPayloadBinary && !this.websocket.binaryType) {
         throw new Error(
           'Attempted to send binary data but data type is set to String. Set binaryType inside onOpen method',

--- a/src/__tests__/ReduxWebSocket.test.ts
+++ b/src/__tests__/ReduxWebSocket.test.ts
@@ -262,9 +262,9 @@ describe('ReduxWebSocket', () => {
     it('should send a ArrayBuffer message', () => {
       const binaryPayload = new Uint8Array([1, 2, 3]).buffer;
       const action = { type: 'SEND', payload: binaryPayload };
-  
+
       reduxWebSocket.connect(store, action as Action);
-      //@ts-ignore
+      // @ts-ignore
       reduxWebSocket.websocket.binaryType = 'arraybuffer';
       reduxWebSocket.send(null as any, { payload: binaryPayload } as any);
 
@@ -273,11 +273,11 @@ describe('ReduxWebSocket', () => {
     });
 
     it('should send a Buffer message', () => {
-      const binaryPayload = new Buffer('test');
+      const binaryPayload = Buffer.from('test');
       const action = { type: 'SEND', payload: binaryPayload };
-  
+
       reduxWebSocket.connect(store, action as Action);
-      //@ts-ignore
+      // @ts-ignore
       reduxWebSocket.websocket.binaryType = 'arraybuffer';
       reduxWebSocket.send(null as any, { payload: binaryPayload } as any);
 
@@ -288,11 +288,11 @@ describe('ReduxWebSocket', () => {
     it('should fail when trying to send a Binary message without setting binaryType', () => {
       const binaryPayload = new Uint8Array([1, 2, 3]).buffer;
       const action = { type: 'SEND', payload: binaryPayload };
-  
+
       reduxWebSocket.connect(store, action as Action);
-  
+
       expect(() => reduxWebSocket.send(null as any, { payload: binaryPayload } as any))
-        .toThrow('Attempted to send binary data while data type is set to String. Set binaryType inside onOpen method');
+        .toThrow('Attempted to send binary data but data type is set to String. Set binaryType inside onOpen method');
     });
 
     it('should throw an error if no connection exists', () => {

--- a/src/__tests__/ReduxWebSocket.test.ts
+++ b/src/__tests__/ReduxWebSocket.test.ts
@@ -259,6 +259,42 @@ describe('ReduxWebSocket', () => {
       expect(sendMock).toHaveBeenCalledWith('{"test":"value"}');
     });
 
+    it('should send a ArrayBuffer message', () => {
+      const binaryPayload = new Uint8Array([1, 2, 3]).buffer;
+      const action = { type: 'SEND', payload: binaryPayload };
+  
+      reduxWebSocket.connect(store, action as Action);
+      //@ts-ignore
+      reduxWebSocket.websocket.binaryType = 'arraybuffer';
+      reduxWebSocket.send(null as any, { payload: binaryPayload } as any);
+
+      expect(sendMock).toHaveBeenCalledTimes(1);
+      expect(sendMock).toHaveBeenCalledWith(binaryPayload);
+    });
+
+    it('should send a Buffer message', () => {
+      const binaryPayload = new Buffer('test');
+      const action = { type: 'SEND', payload: binaryPayload };
+  
+      reduxWebSocket.connect(store, action as Action);
+      //@ts-ignore
+      reduxWebSocket.websocket.binaryType = 'arraybuffer';
+      reduxWebSocket.send(null as any, { payload: binaryPayload } as any);
+
+      expect(sendMock).toHaveBeenCalledTimes(1);
+      expect(sendMock).toHaveBeenCalledWith(binaryPayload);
+    });
+
+    it('should fail when trying to send a Binary message without setting binaryType', () => {
+      const binaryPayload = new Uint8Array([1, 2, 3]).buffer;
+      const action = { type: 'SEND', payload: binaryPayload };
+  
+      reduxWebSocket.connect(store, action as Action);
+  
+      expect(() => reduxWebSocket.send(null as any, { payload: binaryPayload } as any))
+        .toThrow('Attempted to send binary data while data type is set to String. Set binaryType inside onOpen method');
+    });
+
     it('should throw an error if no connection exists', () => {
       expect(() => reduxWebSocket.send(null as any, { payload: null } as any))
         .toThrow('Socket connection not initialized. Dispatch WEBSOCKET_CONNECT first');

--- a/src/__tests__/ReduxWebSocket.test.ts
+++ b/src/__tests__/ReduxWebSocket.test.ts
@@ -272,13 +272,13 @@ describe('ReduxWebSocket', () => {
       expect(sendMock).toHaveBeenCalledWith(binaryPayload);
     });
 
-    it('should send a Buffer message', () => {
+    it('should send a Blob message', () => {
       const binaryPayload = Buffer.from('test');
       const action = { type: 'SEND', payload: binaryPayload };
 
       reduxWebSocket.connect(store, action as Action);
       // @ts-ignore
-      reduxWebSocket.websocket.binaryType = 'arraybuffer';
+      reduxWebSocket.websocket.binaryType = 'blob';
       reduxWebSocket.send(null as any, { payload: binaryPayload } as any);
 
       expect(sendMock).toHaveBeenCalledTimes(1);

--- a/src/__tests__/ReduxWebSocket.test.ts
+++ b/src/__tests__/ReduxWebSocket.test.ts
@@ -273,7 +273,7 @@ describe('ReduxWebSocket', () => {
     });
 
     it('should send a Blob message', () => {
-      const binaryPayload = Buffer.from('test');
+      const binaryPayload = new Blob(['{}'], {type : 'application/json'});
       const action = { type: 'SEND', payload: binaryPayload };
 
       reduxWebSocket.connect(store, action as Action);

--- a/src/__tests__/ReduxWebSocket.test.ts
+++ b/src/__tests__/ReduxWebSocket.test.ts
@@ -273,7 +273,7 @@ describe('ReduxWebSocket', () => {
     });
 
     it('should send a Blob message', () => {
-      const binaryPayload = new Blob(['{}'], {type : 'application/json'});
+      const binaryPayload = new Blob(['{}'], { type: 'application/json' });
       const action = { type: 'SEND', payload: binaryPayload };
 
       reduxWebSocket.connect(store, action as Action);


### PR DESCRIPTION
When using WebSocket at the browser side, data are transmitted as either string or binary, if binary will be used, then the user have to specify `binaryType` in onOpen method:
```
onOpen: socket => {
 socket.binaryType = <'arrayBuffer' or 'blob'>';
}
```