### PR TITLE
Custom Serialization When Sending

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,9 @@ interface Options {
   // Callback when the WebSocket connection is open. Useful for when you
   // need a reference to the WebSocket instance.
   onOpen?: (socket: WebSocket) => void,
-
+  // Custom function to serialize your payload before sending. Defaults to JSON.stringify
+  // but you could use this function to send any format you like, including binary
+  serializer?: (payload: any) => string | ArrayBuffer | ArrayBufferView | Blob
 }
 ```
 

--- a/src/ReduxWebSocket.ts
+++ b/src/ReduxWebSocket.ts
@@ -10,13 +10,14 @@ import {
   reconnectAttempt,
   reconnected,
 } from './actions';
-import { Action } from './types';
+import { Action, Serializer } from './types';
 
 interface ReduxWebSocketOptions {
   prefix: string
   reconnectInterval: number
   reconnectOnClose: boolean
   onOpen?: (s: WebSocket) => void
+  serializer?: Serializer
 }
 
 /**
@@ -103,8 +104,8 @@ export default class ReduxWebSocket {
    * @throws {Error} Socket connection must exist.
    */
   send = (_store: MiddlewareAPI, { payload }: Action) => {
-    if (this.websocket) {
-      this.websocket.send(JSON.stringify(payload));
+    if (this.websocket && this.options.serializer) {
+      this.websocket.send(this.options.serializer(payload));
     } else {
       throw new Error(
         'Socket connection not initialized. Dispatch WEBSOCKET_CONNECT first',

--- a/src/ReduxWebSocket.ts
+++ b/src/ReduxWebSocket.ts
@@ -104,8 +104,14 @@ export default class ReduxWebSocket {
    * @throws {Error} Socket connection must exist.
    */
   send = (_store: MiddlewareAPI, { payload }: Action) => {
-    if (this.websocket && this.options.serializer) {
-      this.websocket.send(this.options.serializer(payload));
+    if (this.websocket) {
+      if (this.options.serializer) {
+        this.websocket.send(this.options.serializer(payload));
+      } else {
+        throw new Error(
+          'Serializer not provided',
+        );
+      }
     } else {
       throw new Error(
         'Socket connection not initialized. Dispatch WEBSOCKET_CONNECT first',

--- a/src/__tests__/ReduxWebSocket.test.ts
+++ b/src/__tests__/ReduxWebSocket.test.ts
@@ -16,6 +16,7 @@ describe('ReduxWebSocket', () => {
     prefix: 'REDUX_WEBSOCKET',
     reconnectInterval: 2000,
     reconnectOnClose: false,
+    serializer: JSON.stringify
   };
   const closeMock = jest.fn();
   const sendMock = jest.fn();

--- a/src/__tests__/ReduxWebSocket.test.ts
+++ b/src/__tests__/ReduxWebSocket.test.ts
@@ -260,6 +260,27 @@ describe('ReduxWebSocket', () => {
       expect(sendMock).toHaveBeenCalledWith('{"test":"value"}');
     });
 
+    it('should send a custom message', () => {
+      const customSerializer = (payload: any) => {
+        // Very basic test custom serializer only works with objects
+        // key1.value1|key2.value2|...|keyN.valueN
+        // console.log(payload)
+        return Object.entries(payload).reduce((acc: string, cv: any) => (
+          `${acc}${acc.length ? '|' : ''}${cv[0]}.${cv[1]}`
+        ), '');
+      }
+      const payload = { test: 'value', another: 'prop' };
+      const action = { type: 'SEND', payload };
+
+      // Pass in a custom serializer
+      reduxWebSocket = new ReduxWebSocket({...options, serializer: customSerializer});
+      reduxWebSocket.connect(store, action as Action);
+      reduxWebSocket.send(null as any, { payload } as any);
+
+      expect(sendMock).toHaveBeenCalledTimes(1);
+      expect(sendMock).toHaveBeenCalledWith(customSerializer(payload));
+    });
+
     it('should throw an error if no connection exists', () => {
       expect(() => reduxWebSocket.send(null as any, { payload: null } as any))
         .toThrow('Socket connection not initialized. Dispatch WEBSOCKET_CONNECT first');

--- a/src/__tests__/ReduxWebSocket.test.ts
+++ b/src/__tests__/ReduxWebSocket.test.ts
@@ -16,7 +16,7 @@ describe('ReduxWebSocket', () => {
     prefix: 'REDUX_WEBSOCKET',
     reconnectInterval: 2000,
     reconnectOnClose: false,
-    serializer: JSON.stringify
+    serializer: JSON.stringify,
   };
   const closeMock = jest.fn();
   const sendMock = jest.fn();
@@ -262,22 +262,22 @@ describe('ReduxWebSocket', () => {
 
     it('should send a custom message', () => {
       const action = { type: 'SEND', payload: { url } };
-      const payload = { test: 'value', another: 'prop' };
-      const customSerializer = (payload: any) => {
-        // Very basic test custom serializer; only works with objects
-        // key1.value1|key2.value2|...|keyN.valueN
-        return Object.entries(payload).reduce((acc: string, cv: any) => (
+      const pld = { test: 'value', another: 'prop' };
+      // Very basic test custom serializer; only works with objects
+      // key1.value1|key2.value2|...|keyN.valueN
+      const customSerializer = (payload: any) => (
+        Object.entries(payload).reduce((acc: string, cv: any) => (
           `${acc}${acc.length ? '|' : ''}${cv[0]}.${cv[1]}`
-        ), '');
-      }
+        ), '')
+      );
 
       // Pass in a custom serializer
-      reduxWebSocket = new ReduxWebSocket({...options, serializer: customSerializer});
+      reduxWebSocket = new ReduxWebSocket({ ...options, serializer: customSerializer });
       reduxWebSocket.connect(store, action as Action);
-      reduxWebSocket.send(null as any, {payload} as any);
+      reduxWebSocket.send(null as any, { pld } as any);
 
       expect(sendMock).toHaveBeenCalledTimes(1);
-      expect(sendMock).toHaveBeenCalledWith(customSerializer(payload));
+      expect(sendMock).toHaveBeenCalledWith(customSerializer(pld));
     });
 
     it('should throw an error if no connection exists', () => {
@@ -286,7 +286,7 @@ describe('ReduxWebSocket', () => {
     });
 
     it('should throw an error if no serializer exists', () => {
-      const optionsClone = {...options};
+      const optionsClone = { ...options };
       const action = { type: 'SEND', payload: { url } };
 
       delete optionsClone.serializer;

--- a/src/__tests__/ReduxWebSocket.test.ts
+++ b/src/__tests__/ReduxWebSocket.test.ts
@@ -1,4 +1,5 @@
 import ReduxWebSocket from '../ReduxWebSocket';
+import { Action } from '../types';
 
 declare global {
   namespace NodeJS {

--- a/src/__tests__/ReduxWebSocket.test.ts
+++ b/src/__tests__/ReduxWebSocket.test.ts
@@ -262,9 +262,8 @@ describe('ReduxWebSocket', () => {
 
     it('should send a custom message', () => {
       const customSerializer = (payload: any) => {
-        // Very basic test custom serializer only works with objects
+        // Very basic test custom serializer; only works with objects
         // key1.value1|key2.value2|...|keyN.valueN
-        // console.log(payload)
         return Object.entries(payload).reduce((acc: string, cv: any) => (
           `${acc}${acc.length ? '|' : ''}${cv[0]}.${cv[1]}`
         ), '');

--- a/src/__tests__/ReduxWebSocket.test.ts
+++ b/src/__tests__/ReduxWebSocket.test.ts
@@ -263,8 +263,8 @@ describe('ReduxWebSocket', () => {
     it('should send a custom message', () => {
       const action = { type: 'SEND', payload: { url } };
       const pld = { test: 'value', another: 'prop' };
-      // Very basic test custom serializer; only works with objects
-      // key1.value1|key2.value2|...|keyN.valueN
+      // Very basic test custom serializer; only works with objects.
+      // Converts object to string: "key1.value1|key2.value2|...|keyN.valueN"
       const customSerializer = (payload: any) => (
         Object.entries(payload).reduce((acc: string, cv: any) => (
           `${acc}${acc.length ? '|' : ''}${cv[0]}.${cv[1]}`
@@ -274,7 +274,7 @@ describe('ReduxWebSocket', () => {
       // Pass in a custom serializer
       reduxWebSocket = new ReduxWebSocket({ ...options, serializer: customSerializer });
       reduxWebSocket.connect(store, action as Action);
-      reduxWebSocket.send(null as any, { pld } as any);
+      reduxWebSocket.send(null as any, { type: 'SEND', payload: pld } as Action);
 
       expect(sendMock).toHaveBeenCalledTimes(1);
       expect(sendMock).toHaveBeenCalledWith(customSerializer(pld));

--- a/src/__tests__/ReduxWebSocket.test.ts
+++ b/src/__tests__/ReduxWebSocket.test.ts
@@ -261,6 +261,8 @@ describe('ReduxWebSocket', () => {
     });
 
     it('should send a custom message', () => {
+      const action = { type: 'SEND', payload: { url } };
+      const payload = { test: 'value', another: 'prop' };
       const customSerializer = (payload: any) => {
         // Very basic test custom serializer; only works with objects
         // key1.value1|key2.value2|...|keyN.valueN
@@ -268,13 +270,11 @@ describe('ReduxWebSocket', () => {
           `${acc}${acc.length ? '|' : ''}${cv[0]}.${cv[1]}`
         ), '');
       }
-      const payload = { test: 'value', another: 'prop' };
-      const action = { type: 'SEND', payload };
 
       // Pass in a custom serializer
       reduxWebSocket = new ReduxWebSocket({...options, serializer: customSerializer});
       reduxWebSocket.connect(store, action as Action);
-      reduxWebSocket.send(null as any, { payload } as any);
+      reduxWebSocket.send(null as any, {payload} as any);
 
       expect(sendMock).toHaveBeenCalledTimes(1);
       expect(sendMock).toHaveBeenCalledWith(customSerializer(payload));
@@ -283,6 +283,18 @@ describe('ReduxWebSocket', () => {
     it('should throw an error if no connection exists', () => {
       expect(() => reduxWebSocket.send(null as any, { payload: null } as any))
         .toThrow('Socket connection not initialized. Dispatch WEBSOCKET_CONNECT first');
+    });
+
+    it('should throw an error if no serializer exists', () => {
+      const optionsClone = {...options};
+      const action = { type: 'SEND', payload: { url } };
+
+      delete optionsClone.serializer;
+      reduxWebSocket = new ReduxWebSocket(optionsClone);
+      reduxWebSocket.connect(store, action as Action);
+
+      expect(() => reduxWebSocket.send(null as any, { payload: null } as any))
+        .toThrow('Serializer not provided');
     });
   });
 

--- a/src/__tests__/createMiddleware.test.ts
+++ b/src/__tests__/createMiddleware.test.ts
@@ -64,7 +64,7 @@ describe('middleware', () => {
       prefix: 'REDUX_WEBSOCKET',
       reconnectInterval: 2000,
       reconnectOnClose: false,
-      serializer: JSON.stringify
+      serializer: JSON.stringify,
     });
   });
 
@@ -75,7 +75,7 @@ describe('middleware', () => {
       prefix: 'CUSTOM',
       reconnectInterval: 2000,
       reconnectOnClose: false,
-      serializer: JSON.stringify
+      serializer: JSON.stringify,
     });
   });
 
@@ -88,13 +88,13 @@ describe('middleware', () => {
       prefix: 'ONE',
       reconnectInterval: 2000,
       reconnectOnClose: false,
-      serializer: JSON.stringify
+      serializer: JSON.stringify,
     });
     expect(ReduxWebSocketMock).toHaveBeenCalledWith({
       prefix: 'TWO',
       reconnectInterval: 2000,
       reconnectOnClose: true,
-      serializer: JSON.stringify
+      serializer: JSON.stringify,
     });
   });
 

--- a/src/__tests__/createMiddleware.test.ts
+++ b/src/__tests__/createMiddleware.test.ts
@@ -64,6 +64,7 @@ describe('middleware', () => {
       prefix: 'REDUX_WEBSOCKET',
       reconnectInterval: 2000,
       reconnectOnClose: false,
+      serializer: JSON.stringify
     });
   });
 
@@ -74,6 +75,7 @@ describe('middleware', () => {
       prefix: 'CUSTOM',
       reconnectInterval: 2000,
       reconnectOnClose: false,
+      serializer: JSON.stringify
     });
   });
 
@@ -86,11 +88,13 @@ describe('middleware', () => {
       prefix: 'ONE',
       reconnectInterval: 2000,
       reconnectOnClose: false,
+      serializer: JSON.stringify
     });
     expect(ReduxWebSocketMock).toHaveBeenCalledWith({
       prefix: 'TWO',
       reconnectInterval: 2000,
       reconnectOnClose: true,
+      serializer: JSON.stringify
     });
   });
 

--- a/src/createMiddleware.ts
+++ b/src/createMiddleware.ts
@@ -13,6 +13,7 @@ const defaultOptions = {
   reconnectInterval: 2000,
   reconnectOnClose: false,
   prefix: actionTypes.DEFAULT_PREFIX,
+  serializer: JSON.stringify
 };
 
 /**

--- a/src/createMiddleware.ts
+++ b/src/createMiddleware.ts
@@ -13,7 +13,7 @@ const defaultOptions = {
   reconnectInterval: 2000,
   reconnectOnClose: false,
   prefix: actionTypes.DEFAULT_PREFIX,
-  serializer: JSON.stringify
+  serializer: JSON.stringify,
 };
 
 /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,6 +7,8 @@ import {
   WEBSOCKET_SEND,
 } from './actionTypes';
 
+type Serializer = (payload: any) => string | ArrayBuffer | ArrayBufferView | Blob
+
 type ActionType =
   | typeof WEBSOCKET_CLOSED
   | typeof WEBSOCKET_CONNECT
@@ -27,7 +29,8 @@ type Options = {
   prefix?: string
   reconnectInterval?: number
   reconnectOnClose?: boolean
-  onOpen?: (s: WebSocket) => void
+  onOpen?: (s: WebSocket) => void,
+  serializer?: Serializer
 }
 
 // Huh? https://github.com/babel/babel/issues/6065#issuecomment-453901877
@@ -36,5 +39,6 @@ export {
   Action,
   ActionType,
   Options,
+  Serializer
 };
 /* eslint-enable no-undef */

--- a/src/types.ts
+++ b/src/types.ts
@@ -30,7 +30,7 @@ type Options = {
   reconnectInterval?: number
   reconnectOnClose?: boolean
   onOpen?: (s: WebSocket) => void,
-  serializer?: Serializer
+  serializer?: Serializer,
 }
 
 // Huh? https://github.com/babel/babel/issues/6065#issuecomment-453901877
@@ -39,6 +39,6 @@ export {
   Action,
   ActionType,
   Options,
-  Serializer
+  Serializer,
 };
 /* eslint-enable no-undef */


### PR DESCRIPTION
Our project has a need to allow different data serialization formats. We use json when we're developing but some of our data is very large so we use different formats in production, including binary. This PR allows the send function to use a custom serializer but uses `JSON.stringify` by default so shouldn't require any changes in use for projects already using this library.

Similar to #97 but doesn't need to check for binary data and allows more than just JSON when not using binary.