### PR TITLE
Fix #103 reconnect on close loop

### DIFF
--- a/demo/package-lock.json
+++ b/demo/package-lock.json
@@ -288,9 +288,9 @@
       "integrity": "sha512-4zAPlpDEh2VwXswwr/t8xGNDGg8RQiPxtxZ3qQEXyQsBV39ptTdESCjuBvGze1nLMVrxmTIKmnO/nAV8Tqjjzg=="
     },
     "@giantmachines/redux-websocket": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@giantmachines/redux-websocket/-/redux-websocket-1.1.2.tgz",
-      "integrity": "sha512-dOAfIiaNHou7mrGkPJ4rAT5HpXGF2QdBOCjh/OTsQ1sGU1EyH6qdX4qFl45ZEMEMUh7FKnmsp4b9HaUdBoNGzg==",
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@giantmachines/redux-websocket/-/redux-websocket-1.1.7.tgz",
+      "integrity": "sha512-t90k+NcVInXvppMVpU3c7ZC6i58S/jBPqltckAlKfrtc92YmGZ/He3qYT9OiemlvS+/d+R6P/Ed4yEqKVevYdg==",
       "requires": {
         "redux": "~4"
       }

--- a/src/__tests__/ReduxWebSocket.test.ts
+++ b/src/__tests__/ReduxWebSocket.test.ts
@@ -277,11 +277,11 @@ describe('ReduxWebSocket', () => {
       jest.advanceTimersByTime(5000);
 
       // Make sure we actually check all of the calls to `dispatch`.
-      expect.assertions(7);
+      expect.assertions(6);
 
-      expect(dispatch).toHaveBeenCalledTimes(5);
+      expect(dispatch).toHaveBeenCalledTimes(4);
       // @ts-ignore
-      expect(reduxWebSocket.reconnectCount).toEqual(3);
+      expect(reduxWebSocket.reconnectCount).toEqual(2);
       expect(dispatch).toHaveBeenNthCalledWith(1, {
         type: 'REDUX_WEBSOCKET::BROKEN',
         meta: {
@@ -310,15 +310,6 @@ describe('ReduxWebSocket', () => {
         },
         payload: {
           count: 2,
-        },
-      });
-      expect(dispatch).toHaveBeenNthCalledWith(5, {
-        type: 'REDUX_WEBSOCKET::RECONNECT_ATTEMPT',
-        meta: {
-          timestamp: expect.any(Date),
-        },
-        payload: {
-          count: 3,
         },
       });
     });


### PR DESCRIPTION
- Reconnect will now only occur if connection was not closed cleanly
- Remove immediate reconnection attempt when handling broken connection