### PR TITLE
Update tests to remove casting of Action & any and all ts-ignore

### DIFF
--- a/demo/package-lock.json
+++ b/demo/package-lock.json
@@ -288,9 +288,9 @@
       "integrity": "sha512-4zAPlpDEh2VwXswwr/t8xGNDGg8RQiPxtxZ3qQEXyQsBV39ptTdESCjuBvGze1nLMVrxmTIKmnO/nAV8Tqjjzg=="
     },
     "@giantmachines/redux-websocket": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@giantmachines/redux-websocket/-/redux-websocket-1.1.2.tgz",
-      "integrity": "sha512-dOAfIiaNHou7mrGkPJ4rAT5HpXGF2QdBOCjh/OTsQ1sGU1EyH6qdX4qFl45ZEMEMUh7FKnmsp4b9HaUdBoNGzg==",
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@giantmachines/redux-websocket/-/redux-websocket-1.1.7.tgz",
+      "integrity": "sha512-t90k+NcVInXvppMVpU3c7ZC6i58S/jBPqltckAlKfrtc92YmGZ/He3qYT9OiemlvS+/d+R6P/Ed4yEqKVevYdg==",
       "requires": {
         "redux": "~4"
       }
@@ -773,9 +773,9 @@
       "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
     },
     "aws4": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
-      "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ=="
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.9.1.tgz",
+      "integrity": "sha512-wMHVg2EOHaMRxbzgFJ9gtjOOCrI80OHLG14rxi28XwOW8ux6IiEbRCGGGqCtdAIg4FQCbW20k9RsT4y3gJlFug=="
     },
     "babel-plugin-styled-components": {
       "version": "1.10.0",
@@ -1387,9 +1387,9 @@
       }
     },
     "combined-stream": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.7.tgz",
-      "integrity": "sha512-brWl9y6vOB1xYPZcpZde3N9zDByXTosAeMDo4p1wzo6UMOX4vumB+TP1RZ76sfE6Md68Q0NJSrE/gbezd4Ul+w==",
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
       "requires": {
         "delayed-stream": "~1.0.0"
       }
@@ -2397,6 +2397,25 @@
         "unpipe": "~1.0.0"
       }
     },
+    "find-up": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
+      "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+      "requires": {
+        "path-exists": "^2.0.0",
+        "pinkie-promise": "^2.0.0"
+      },
+      "dependencies": {
+        "path-exists": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
+          "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+          "requires": {
+            "pinkie-promise": "^2.0.0"
+          }
+        }
+      }
+    },
     "findup-sync": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-2.0.0.tgz",
@@ -2538,8 +2557,7 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -2557,13 +2575,11 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -2576,18 +2592,15 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -2690,8 +2703,7 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "ini": {
           "version": "1.3.5",
@@ -2701,7 +2713,6 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -2714,20 +2725,17 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -2744,7 +2752,6 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -2817,8 +2824,7 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -2828,7 +2834,6 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -2904,8 +2909,7 @@
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -2935,7 +2939,6 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -2953,7 +2956,6 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -2992,13 +2994,11 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "yallist": {
           "version": "3.0.3",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         }
       }
     },
@@ -3184,12 +3184,12 @@
       }
     },
     "globule": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/globule/-/globule-1.2.1.tgz",
-      "integrity": "sha512-g7QtgWF4uYSL5/dn71WxubOrS7JVGCnFPEnoeChJmBnyR9Mw8nGoEwOgJL/RC2Te0WhbsEUCejfH8SZNJ+adYQ==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/globule/-/globule-1.3.1.tgz",
+      "integrity": "sha512-OVyWOHgw29yosRHCHo7NncwR1hW5ew0W/UrvtwvjefVJeQ26q4/8r8FmPsSF1hJ93IgWkyv16pCTz6WblMzm/g==",
       "requires": {
         "glob": "~7.1.1",
-        "lodash": "~4.17.10",
+        "lodash": "~4.17.12",
         "minimatch": "~3.0.2"
       }
     },
@@ -3348,9 +3348,9 @@
       }
     },
     "hosted-git-info": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.7.1.tgz",
-      "integrity": "sha512-7T/BxH19zbcCTa8XkMlbK5lTo1WtgkFi3GvdWEyNuc4Vex7/9Dqbnpsf4JMydcfj9HCg4zUWFTL3Za6lapg5/w=="
+      "version": "2.8.8",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.8.tgz",
+      "integrity": "sha512-f/wzC2QaWBs7t9IYqB4T3sR1xviIViXJRJTWBlx2Gf3g0Xi5vI7Yy4koXQ1c9OYDGHN9sBy1DQ2AB8fqZBWhUg=="
     },
     "hpack.js": {
       "version": "2.1.6",
@@ -3604,9 +3604,9 @@
       "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o="
     },
     "in-publish": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/in-publish/-/in-publish-2.0.0.tgz",
-      "integrity": "sha1-4g/146KvwmkDILbcVSaCqcf631E="
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/in-publish/-/in-publish-2.0.1.tgz",
+      "integrity": "sha512-oDM0kUSNFC31ShNxHKUyfZKy8ZeXZBWMjMdZHKLOk13uvT27VTL/QzRGfRUcevJhpkZAvlhPYuXkF7eNWrtyxQ=="
     },
     "indent-string": {
       "version": "2.1.0",
@@ -3781,12 +3781,9 @@
       "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI="
     },
     "is-finite": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
-      "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
-      "requires": {
-        "number-is-nan": "^1.0.0"
-      }
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.1.0.tgz",
+      "integrity": "sha512-cdyMtqX/BOqqNBBiKlIVkytNHm49MtMlYyn1zxzvJKWmFMlGzm+ry5BBfYyeY9YmNKbRSo/o7OX9w9ale0wg3w=="
     },
     "is-fullwidth-code-point": {
       "version": "2.0.0",
@@ -3920,9 +3917,9 @@
       "integrity": "sha1-FC0RHzpuPa6PSpr9d9RYVbWpzOM="
     },
     "js-base64": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.5.1.tgz",
-      "integrity": "sha512-M7kLczedRMYX4L8Mdh4MzyAMM9O5osx+4FcOQuTvr3A9F2D9S5JXheN0ewNbrvK2UatkTRhL5ejGmGSjNMiZuw=="
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.5.2.tgz",
+      "integrity": "sha512-Vg8czh0Q7sFBSUMWWArX/miJeBWYBPpdU/3M/DKSaekLMqrqVPaedp+5mZhie/r0lgrcaYBfwXatEew6gwgiQQ=="
     },
     "js-tokens": {
       "version": "4.0.0",
@@ -4078,6 +4075,25 @@
         "invert-kv": "^2.0.0"
       }
     },
+    "load-json-file": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+      "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
+      "requires": {
+        "graceful-fs": "^4.1.2",
+        "parse-json": "^2.2.0",
+        "pify": "^2.0.0",
+        "pinkie-promise": "^2.0.0",
+        "strip-bom": "^2.0.0"
+      },
+      "dependencies": {
+        "pify": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
+        }
+      }
+    },
     "loader-runner": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-2.4.0.tgz",
@@ -4113,16 +4129,6 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
       "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
     },
-    "lodash.assign": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz",
-      "integrity": "sha1-DZnzzNem0mHRm9rrkkUAXShYCOc="
-    },
-    "lodash.clonedeep": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
-      "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8="
-    },
     "lodash.curry": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lodash.curry/-/lodash.curry-4.1.1.tgz",
@@ -4137,11 +4143,6 @@
       "version": "3.5.0",
       "resolved": "https://registry.npmjs.org/lodash.flow/-/lodash.flow-3.5.0.tgz",
       "integrity": "sha1-h79AKSuM+D5OjOGjrkIJ4gBxZ1o="
-    },
-    "lodash.mergewith": {
-      "version": "4.6.2",
-      "resolved": "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.2.tgz",
-      "integrity": "sha512-GK3g5RPZWTRSeLSpgP8Xhra+pnjBC56q9FZYe1d5RN3TJ35dbkGy3YqBSMbyCrlbi+CM9Z3Jk5yTL7RCsqboyQ=="
     },
     "lodash.tail": {
       "version": "4.1.1",
@@ -4290,81 +4291,10 @@
         "trim-newlines": "^1.0.0"
       },
       "dependencies": {
-        "find-up": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
-          "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
-          "requires": {
-            "path-exists": "^2.0.0",
-            "pinkie-promise": "^2.0.0"
-          }
-        },
-        "load-json-file": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
-          "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
-          "requires": {
-            "graceful-fs": "^4.1.2",
-            "parse-json": "^2.2.0",
-            "pify": "^2.0.0",
-            "pinkie-promise": "^2.0.0",
-            "strip-bom": "^2.0.0"
-          }
-        },
         "minimist": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
-        },
-        "path-exists": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
-          "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
-          "requires": {
-            "pinkie-promise": "^2.0.0"
-          }
-        },
-        "path-type": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
-          "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
-          "requires": {
-            "graceful-fs": "^4.1.2",
-            "pify": "^2.0.0",
-            "pinkie-promise": "^2.0.0"
-          }
-        },
-        "pify": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
-        },
-        "read-pkg": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
-          "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
-          "requires": {
-            "load-json-file": "^1.0.0",
-            "normalize-package-data": "^2.3.2",
-            "path-type": "^1.0.0"
-          }
-        },
-        "read-pkg-up": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
-          "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
-          "requires": {
-            "find-up": "^1.0.0",
-            "read-pkg": "^1.0.0"
-          }
-        },
-        "strip-bom": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
-          "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
-          "requires": {
-            "is-utf8": "^0.2.0"
-          }
+          "version": "1.2.5",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
         }
       }
     },
@@ -4556,7 +4486,8 @@
     "nan": {
       "version": "2.12.1",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.12.1.tgz",
-      "integrity": "sha512-JY7V6lRkStKcKTvHO5NVSQRv+RV+FIL5pvDoLiAtSL9pKlC5x9PKQcZDsq7m4FO4d57mkhC6Z+QhAh3Jdk5JFw=="
+      "integrity": "sha512-JY7V6lRkStKcKTvHO5NVSQRv+RV+FIL5pvDoLiAtSL9pKlC5x9PKQcZDsq7m4FO4d57mkhC6Z+QhAh3Jdk5JFw==",
+      "optional": true
     },
     "nanomatch": {
       "version": "1.2.13",
@@ -4673,9 +4604,9 @@
       }
     },
     "node-sass": {
-      "version": "4.11.0",
-      "resolved": "https://registry.npmjs.org/node-sass/-/node-sass-4.11.0.tgz",
-      "integrity": "sha512-bHUdHTphgQJZaF1LASx0kAviPH7sGlcyNhWade4eVIpFp6tsn7SV8xNMTbsQFpEV9VXpnwTTnNYlfsZXgGgmkA==",
+      "version": "4.13.1",
+      "resolved": "https://registry.npmjs.org/node-sass/-/node-sass-4.13.1.tgz",
+      "integrity": "sha512-TTWFx+ZhyDx1Biiez2nB0L3YrCZ/8oHagaDalbuBSlqXgUPsdkUSzJsVxeDO9LtPB49+Fh3WQl3slABo6AotNw==",
       "requires": {
         "async-foreach": "^0.1.3",
         "chalk": "^1.1.1",
@@ -4684,12 +4615,10 @@
         "get-stdin": "^4.0.1",
         "glob": "^7.0.3",
         "in-publish": "^2.0.0",
-        "lodash.assign": "^4.2.0",
-        "lodash.clonedeep": "^4.3.2",
-        "lodash.mergewith": "^4.6.0",
+        "lodash": "^4.17.15",
         "meow": "^3.7.0",
         "mkdirp": "^0.5.1",
-        "nan": "^2.10.0",
+        "nan": "^2.13.2",
         "node-gyp": "^3.8.0",
         "npmlog": "^4.0.0",
         "request": "^2.88.0",
@@ -4745,6 +4674,11 @@
             "pseudomap": "^1.0.2",
             "yallist": "^2.1.2"
           }
+        },
+        "nan": {
+          "version": "2.14.0",
+          "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
+          "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg=="
         },
         "strip-ansi": {
           "version": "3.0.1",
@@ -5096,6 +5030,23 @@
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
       "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w="
     },
+    "path-type": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
+      "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
+      "requires": {
+        "graceful-fs": "^4.1.2",
+        "pify": "^2.0.0",
+        "pinkie-promise": "^2.0.0"
+      },
+      "dependencies": {
+        "pify": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
+        }
+      }
+    },
     "pbkdf2": {
       "version": "3.0.17",
       "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.17.tgz",
@@ -5304,9 +5255,9 @@
       "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
     },
     "psl": {
-      "version": "1.1.31",
-      "resolved": "https://registry.npmjs.org/psl/-/psl-1.1.31.tgz",
-      "integrity": "sha512-/6pt4+C+T+wZUieKR620OpzN/LlnNKuWjy1iFLQ/UG35JqHlR/89MP1d96dUfkf6Dne3TuLQzOYEYshJ+Hx8mw=="
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz",
+      "integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ=="
     },
     "public-encrypt": {
       "version": "4.0.3",
@@ -5499,6 +5450,25 @@
         "react-is": "^16.6.3"
       }
     },
+    "read-pkg": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
+      "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
+      "requires": {
+        "load-json-file": "^1.0.0",
+        "normalize-package-data": "^2.3.2",
+        "path-type": "^1.0.0"
+      }
+    },
+    "read-pkg-up": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
+      "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
+      "requires": {
+        "find-up": "^1.0.0",
+        "read-pkg": "^1.0.0"
+      }
+    },
     "readable-stream": {
       "version": "2.3.6",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
@@ -5663,9 +5633,9 @@
       }
     },
     "request": {
-      "version": "2.88.0",
-      "resolved": "https://registry.npmjs.org/request/-/request-2.88.0.tgz",
-      "integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
+      "version": "2.88.2",
+      "resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
+      "integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
       "requires": {
         "aws-sign2": "~0.7.0",
         "aws4": "^1.8.0",
@@ -5674,7 +5644,7 @@
         "extend": "~3.0.2",
         "forever-agent": "~0.6.1",
         "form-data": "~2.3.2",
-        "har-validator": "~5.1.0",
+        "har-validator": "~5.1.3",
         "http-signature": "~1.2.0",
         "is-typedarray": "~1.0.0",
         "isstream": "~0.1.2",
@@ -5684,25 +5654,9 @@
         "performance-now": "^2.1.0",
         "qs": "~6.5.2",
         "safe-buffer": "^5.1.2",
-        "tough-cookie": "~2.4.3",
+        "tough-cookie": "~2.5.0",
         "tunnel-agent": "^0.6.0",
         "uuid": "^3.3.2"
-      },
-      "dependencies": {
-        "punycode": {
-          "version": "1.4.1",
-          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-          "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
-        },
-        "tough-cookie": {
-          "version": "2.4.3",
-          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
-          "integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
-          "requires": {
-            "psl": "^1.1.24",
-            "punycode": "^1.4.1"
-          }
-        }
       }
     },
     "require-directory": {
@@ -5836,15 +5790,6 @@
             "wrap-ansi": "^2.0.0"
           }
         },
-        "find-up": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
-          "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
-          "requires": {
-            "path-exists": "^2.0.0",
-            "pinkie-promise": "^2.0.0"
-          }
-        },
         "invert-kv": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
@@ -5866,66 +5811,12 @@
             "invert-kv": "^1.0.0"
           }
         },
-        "load-json-file": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
-          "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
-          "requires": {
-            "graceful-fs": "^4.1.2",
-            "parse-json": "^2.2.0",
-            "pify": "^2.0.0",
-            "pinkie-promise": "^2.0.0",
-            "strip-bom": "^2.0.0"
-          }
-        },
         "os-locale": {
           "version": "1.4.0",
           "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
           "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
           "requires": {
             "lcid": "^1.0.0"
-          }
-        },
-        "path-exists": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
-          "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
-          "requires": {
-            "pinkie-promise": "^2.0.0"
-          }
-        },
-        "path-type": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
-          "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
-          "requires": {
-            "graceful-fs": "^4.1.2",
-            "pify": "^2.0.0",
-            "pinkie-promise": "^2.0.0"
-          }
-        },
-        "pify": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
-        },
-        "read-pkg": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
-          "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
-          "requires": {
-            "load-json-file": "^1.0.0",
-            "normalize-package-data": "^2.3.2",
-            "path-type": "^1.0.0"
-          }
-        },
-        "read-pkg-up": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
-          "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
-          "requires": {
-            "find-up": "^1.0.0",
-            "read-pkg": "^1.0.0"
           }
         },
         "string-width": {
@@ -5944,14 +5835,6 @@
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "requires": {
             "ansi-regex": "^2.0.0"
-          }
-        },
-        "strip-bom": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
-          "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
-          "requires": {
-            "is-utf8": "^0.2.0"
           }
         },
         "which-module": {
@@ -6417,9 +6300,9 @@
       }
     },
     "spdx-license-ids": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.3.tgz",
-      "integrity": "sha512-uBIcIl3Ih6Phe3XHK1NqboJLdGfwr1UN3k6wSD1dZpmPsIkb8AGNbZYJ1fOBk834+Gxy8rpfDxrS6XLEMZMY2g=="
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.5.tgz",
+      "integrity": "sha512-J+FWzZoynJEXGphVIS+XEh3kFSjZX/1i9gFBaWQcB+/tmpe2qUsSBABpcxqxnAxFdiUFEgAX1bjYGQvIZmoz9Q=="
     },
     "spdy": {
       "version": "4.0.0",
@@ -6608,6 +6491,14 @@
       "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
       "requires": {
         "ansi-regex": "^3.0.0"
+      }
+    },
+    "strip-bom": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+      "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+      "requires": {
+        "is-utf8": "^0.2.0"
       }
     },
     "strip-eof": {
@@ -6868,6 +6759,15 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/toposort/-/toposort-1.0.7.tgz",
       "integrity": "sha1-LmhELZ9k7HILjMieZEOsbKqVACk="
+    },
+    "tough-cookie": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
+      "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
+      "requires": {
+        "psl": "^1.1.28",
+        "punycode": "^2.1.1"
+      }
     },
     "trim-newlines": {
       "version": "1.0.0",

--- a/demo/package.json
+++ b/demo/package.json
@@ -25,7 +25,7 @@
     "css-loader": "2.1.0",
     "debounce": "1.2.0",
     "html-webpack-plugin": "3.2.0",
-    "node-sass": "4.11.0",
+    "node-sass": "4.13.1",
     "polished": "3.1.0",
     "prismjs": "1.15.0",
     "react": "16.8.1",

--- a/src/__tests__/ReduxWebSocket.test.ts
+++ b/src/__tests__/ReduxWebSocket.test.ts
@@ -1,5 +1,4 @@
 import ReduxWebSocket from '../ReduxWebSocket';
-import { Action } from '../types';
 
 declare global {
   namespace NodeJS {
@@ -9,8 +8,11 @@ declare global {
   }
 }
 
+const CONNECT = 'CONNECT' as 'CONNECT';
+const SEND = 'SEND' as 'SEND';
+
 describe('ReduxWebSocket', () => {
-  const store = { dispatch: jest.fn((i: any) => i), getState: () => {} };
+  const store = { dispatch: jest.fn((i: any) => i), getState: () => { } };
   const url = 'ws://fake.com';
   const options = {
     prefix: 'REDUX_WEBSOCKET',
@@ -39,10 +41,10 @@ describe('ReduxWebSocket', () => {
   });
 
   describe('connect', () => {
-    const action = { type: 'SEND', payload: { url } };
+    const action = { type: SEND, payload: { url } };
 
     beforeEach(() => {
-      reduxWebSocket.connect(store, action as Action);
+      reduxWebSocket.connect(store, action);
     });
 
     it('creates a new WebSocket instance', () => {
@@ -51,7 +53,7 @@ describe('ReduxWebSocket', () => {
     });
 
     it('closes any existing connections', () => {
-      reduxWebSocket.connect(store, action as Action);
+      reduxWebSocket.connect(store, action);
 
       expect(closeMock).toHaveBeenCalledTimes(1);
       expect(closeMock).toHaveBeenCalledWith(1000, 'WebSocket connection closed by redux-websocket.');
@@ -85,14 +87,18 @@ describe('ReduxWebSocket', () => {
       const rws = new ReduxWebSocket({
         ...options,
         reconnectOnClose: true,
-      }) as any; // cast to avoid compile errors
-      rws.handleBrokenConnection = jest.fn();
-      rws.handleClose(dispatch, 'prefix', { currentTarget: { url: 'test' } } as any);
-      expect(rws.handleBrokenConnection).not.toHaveBeenCalled();
-      rws.hasOpened = true;
-      rws.handleClose(dispatch, 'prefix', { currentTarget: { url: 'test' } } as any);
-      expect(rws.handleBrokenConnection).toHaveBeenCalledTimes(1);
-      expect(rws.handleBrokenConnection).toHaveBeenCalledWith(dispatch);
+      });
+      const event = new Event('');
+
+      /* eslint-disable dot-notation */
+      rws['handleBrokenConnection'] = jest.fn();
+      rws['handleClose'](dispatch, 'prefix', event);
+      expect(rws['handleBrokenConnection']).not.toHaveBeenCalled();
+      rws['hasOpened'] = true;
+      rws['handleClose'](dispatch, 'prefix', event);
+      expect(rws['handleBrokenConnection']).toHaveBeenCalledTimes(1);
+      expect(rws['handleBrokenConnection']).toHaveBeenCalledWith(dispatch);
+      /* eslint-enable dot-notation */
     });
 
     it('handles a message event', () => {
@@ -140,26 +146,16 @@ describe('ReduxWebSocket', () => {
       it('calls handleBrokenConnection', () => {
         const dispatch = jest.fn();
 
-        // @ts-ignore
-        reduxWebSocket.handleBrokenConnection = jest.fn();
+        /* eslint-disable dot-notation */
+        reduxWebSocket['handleBrokenConnection'] = jest.fn();
+        reduxWebSocket['handleError'](dispatch, 'prefix');
+        expect(reduxWebSocket['handleBrokenConnection']).not.toHaveBeenCalled();
 
-        // @ts-ignore
-        reduxWebSocket.handleError(dispatch, 'prefix', { currentTarget: { url: 'test' } } as any);
-
-        // @ts-ignore
-        expect(reduxWebSocket.handleBrokenConnection).not.toHaveBeenCalled();
-
-        // @ts-ignore
-        reduxWebSocket.hasOpened = true;
-
-        // @ts-ignore
-        reduxWebSocket.handleError(dispatch, 'prefix', { currentTarget: { url: 'test' } } as any);
-
-        // @ts-ignore
-        expect(reduxWebSocket.handleBrokenConnection).toHaveBeenCalledTimes(1);
-
-        // @ts-ignore
-        expect(reduxWebSocket.handleBrokenConnection).toHaveBeenCalledWith(dispatch);
+        reduxWebSocket['hasOpened'] = true;
+        reduxWebSocket['handleError'](dispatch, 'prefix');
+        expect(reduxWebSocket['handleBrokenConnection']).toHaveBeenCalledTimes(1);
+        expect(reduxWebSocket['handleBrokenConnection']).toHaveBeenCalledWith(dispatch);
+        /* eslint-enable dot-notation */
       });
     });
 
@@ -169,6 +165,7 @@ describe('ReduxWebSocket', () => {
 
         event[1]();
 
+        /* eslint-disable dot-notation */
         expect(store.dispatch).toHaveBeenCalledTimes(1);
         expect(store.dispatch).toHaveBeenCalledWith({
           type: 'REDUX_WEBSOCKET::OPEN',
@@ -176,42 +173,39 @@ describe('ReduxWebSocket', () => {
             timestamp: expect.any(Date),
           },
         });
-        // @ts-ignore
-        expect(reduxWebSocket.hasOpened).toEqual(true);
+        expect(reduxWebSocket['hasOpened']).toEqual(true);
+        /* eslint-enable dot-notation */
       });
 
       it('calls an onOpen function with a reference to the opened socket', () => {
         const onOpen = jest.fn();
 
-        // @ts-ignore
-        reduxWebSocket.options.onOpen = onOpen;
-        reduxWebSocket.connect(store, action as Action);
+        /* eslint-disable dot-notation */
+        reduxWebSocket['options'].onOpen = onOpen;
+        reduxWebSocket.connect(store, action);
 
         const event = addEventListenerMock.mock.calls.find(call => call[0] === 'open');
 
         event[1]('test event');
 
         expect(onOpen).toHaveBeenCalledTimes(1);
-        // @ts-ignore
-        expect(onOpen).toHaveBeenCalledWith(reduxWebSocket.websocket);
+        expect(onOpen).toHaveBeenCalledWith(reduxWebSocket['websocket']);
+        /* eslint-enable dot-notation */
       });
 
       it('handles successful reconnection', () => {
         const event = addEventListenerMock.mock.calls.find(call => call[0] === 'open');
 
-        // @ts-ignore
-        reduxWebSocket.reconnectionInterval = 'truthy';
-        // @ts-ignore
-        reduxWebSocket.reconnectCount = 9999;
+        /* eslint-disable dot-notation */
+        reduxWebSocket['reconnectionInterval'] = 1000 as any;
+        reduxWebSocket['reconnectCount'] = 9999;
 
         global.clearInterval = jest.fn();
 
         event[1]('test event');
 
-        // @ts-ignore
-        expect(reduxWebSocket.reconnectionInterval).toBeNull();
-        // @ts-ignore
-        expect(reduxWebSocket.reconnectCount).toEqual(0);
+        expect(reduxWebSocket['reconnectionInterval']).toBeNull();
+        expect(reduxWebSocket['reconnectCount']).toEqual(0);
 
         // Once for the reconnected action, once for the open action.
         expect(store.dispatch).toHaveBeenCalledTimes(2);
@@ -228,15 +222,16 @@ describe('ReduxWebSocket', () => {
           },
           payload: 'test event',
         });
+        /* eslint-enable dot-notation */
       });
     });
   });
 
   describe('disconnect', () => {
     it('should close any open connection', () => {
-      const action = { type: 'SEND', payload: { url } };
+      const action = { type: SEND, payload: { url } };
 
-      reduxWebSocket.connect(store, action as Action);
+      reduxWebSocket.connect(store, action);
       reduxWebSocket.disconnect();
 
       expect(closeMock).toHaveBeenCalledTimes(1);
@@ -249,18 +244,24 @@ describe('ReduxWebSocket', () => {
   });
 
   describe('send', () => {
-    it('should send a JSON message', () => {
-      const action = { type: 'SEND', payload: { url } };
+    const sendAction = { type: SEND, payload: { test: 'value' } };
+    const middlewareApi = {
+      dispatch: jest.fn(),
+      getState: jest.fn(),
+    };
 
-      reduxWebSocket.connect(store, action as Action);
-      reduxWebSocket.send(null as any, { payload: { test: 'value' } } as any);
+    it('should send a JSON message', () => {
+      const connectAction = { type: CONNECT, payload: { url } };
+
+      reduxWebSocket.connect(store, connectAction);
+      reduxWebSocket.send(middlewareApi, sendAction);
 
       expect(sendMock).toHaveBeenCalledTimes(1);
       expect(sendMock).toHaveBeenCalledWith('{"test":"value"}');
     });
 
     it('should throw an error if no connection exists', () => {
-      expect(() => reduxWebSocket.send(null as any, { payload: null } as any))
+      expect(() => reduxWebSocket.send(middlewareApi, sendAction))
         .toThrow('Socket connection not initialized. Dispatch WEBSOCKET_CONNECT first');
     });
   });
@@ -271,8 +272,8 @@ describe('ReduxWebSocket', () => {
     it('should reconnect on an interval', () => {
       const dispatch = jest.fn();
 
-      // @ts-ignore
-      reduxWebSocket.handleBrokenConnection(dispatch);
+      /* eslint-disable dot-notation */
+      reduxWebSocket['handleBrokenConnection'](dispatch);
 
       jest.advanceTimersByTime(5000);
 
@@ -280,8 +281,7 @@ describe('ReduxWebSocket', () => {
       expect.assertions(7);
 
       expect(dispatch).toHaveBeenCalledTimes(5);
-      // @ts-ignore
-      expect(reduxWebSocket.reconnectCount).toEqual(3);
+      expect(reduxWebSocket['reconnectCount']).toEqual(3);
       expect(dispatch).toHaveBeenNthCalledWith(1, {
         type: 'REDUX_WEBSOCKET::BROKEN',
         meta: {
@@ -321,6 +321,7 @@ describe('ReduxWebSocket', () => {
           count: 3,
         },
       });
+      /* eslint-enable dot-notation */
     });
   });
 });

--- a/src/__tests__/actions.test.ts
+++ b/src/__tests__/actions.test.ts
@@ -156,33 +156,31 @@ describe('actions', () => {
 
     describe('closed', () => {
       it('should return the correct action', () => {
-        const act = actions.closed({ test: 'value' } as any, PREFIX);
+        const event = new Event('');
+        const act = actions.closed(event, PREFIX);
 
         expect(isFSA(act)).toBe(true);
         expect(act).toEqual({
           type: `${PREFIX}::${actionTypes.WEBSOCKET_CLOSED}`,
           meta: { timestamp: expect.any(Date) },
-          payload: {
-            test: 'value',
-          },
+          payload: event,
         });
       });
     });
 
     describe('message', () => {
       it('should return the correct action', () => {
-        const act = actions.message({ test: 'value' } as any, PREFIX);
+        const event = new MessageEvent('');
+        const act = actions.message(event, PREFIX);
 
         expect(isFSA(act)).toBe(true);
         expect(act).toEqual({
           type: `${PREFIX}::${actionTypes.WEBSOCKET_MESSAGE}`,
           meta: { timestamp: expect.any(Date) },
           payload: {
-            event: {
-              test: 'value',
-            },
-            message: undefined,
-            origin: undefined,
+            event,
+            message: null,
+            origin: event.origin,
           },
         });
       });
@@ -190,15 +188,14 @@ describe('actions', () => {
 
     describe('open', () => {
       it('should return the correct action', () => {
-        const act = actions.open({ test: 'value' } as any, PREFIX);
+        const event = new Event('');
+        const act = actions.open(event, PREFIX);
 
         expect(isFSA(act)).toBe(true);
         expect(act).toEqual({
           type: `${PREFIX}::${actionTypes.WEBSOCKET_OPEN}`,
           meta: { timestamp: expect.any(Date) },
-          payload: {
-            test: 'value',
-          },
+          payload: event,
         });
       });
     });
@@ -218,7 +215,8 @@ describe('actions', () => {
     describe('error', () => {
       it('should return the correct action with a test action', () => {
         const err = new Error('test');
-        const act = actions.error({ type: 'TEST' } as any, err, PREFIX);
+        const originalAction = { type: 'SEND' as 'SEND', payload: null };
+        const act = actions.error(originalAction, err, PREFIX);
 
         expect(isFSA(act)).toBe(true);
         expect(isError(act)).toBe(true);
@@ -229,9 +227,7 @@ describe('actions', () => {
             timestamp: expect.any(Date),
             message: 'test',
             name: 'Error',
-            originalAction: {
-              type: 'TEST',
-            },
+            originalAction,
           },
           payload: err,
         });


### PR DESCRIPTION
Objective: Remove as many `as Action` and `as any` type casting due to casting potentially leading to errors. General a poor practice and should not be done within the repository.

Removed `ts-ignore` which was used in place of getting private methods. Rather than using `ts-ignore` and removing the type safety from those lines we can use bracket notation to access these private methods and disable the `dot-notation` linting around those particular blocks of code.