### PR TITLE
Make it possible to use JSON serialized Date string as timestamp

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ You may also pass options to the `reduxWebsocket` function.
 interface Options {
   // Defaults to false. If false, meta.timestamp will be a Date. If true, the timestamp won't be a
   // Date but instead a JSON serialized date represented as a string.
-  stringTimestamp: boolean,
+  stringTimestamp?: boolean,
   // Defaults to 'REDUX_WEBSOCKET'. Use this option to set a custom action type
   // prefix. This is useful when you're creating multiple instances of the
   // middleware, and need to handle actions dispatched by each middleware instance separately.

--- a/README.md
+++ b/README.md
@@ -44,6 +44,9 @@ You may also pass options to the `reduxWebsocket` function.
 
 ```js
 interface Options {
+  // Defaults to false. If false, meta.timestamp will be a Date. If true, the timestamp won't be a
+  // Date but instead a JSON serialized date represented as a string.
+  stringTimestamp: boolean,
   // Defaults to 'REDUX_WEBSOCKET'. Use this option to set a custom action type
   // prefix. This is useful when you're creating multiple instances of the
   // middleware, and need to handle actions dispatched by each middleware instance separately.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@giantmachines/redux-websocket",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "A redux middleware to handle websocket connections",
   "main": "dist",
   "files": [

--- a/src/ReduxWebSocket.ts
+++ b/src/ReduxWebSocket.ts
@@ -165,12 +165,7 @@ export default class ReduxWebSocket {
     prefix: string
   ) => {
     dispatch(
-      error(
-        null,
-        new Error('`redux-websocket` error'),
-        stringTimestamp,
-        prefix
-      )
+      error(null, new Error('`redux-websocket` error'), stringTimestamp, prefix)
     );
     if (this.canAttemptReconnect()) {
       this.handleBrokenConnection(dispatch);

--- a/src/__tests__/ReduxWebSocket.test.ts
+++ b/src/__tests__/ReduxWebSocket.test.ts
@@ -326,7 +326,8 @@ describe('ReduxWebSocket', () => {
       });
 
       const call = store.dispatch.mock.calls[0][0];
-      const timestamp: string = call.meta.timestamp;
+      const { meta } = call;
+      const { timestamp } = meta;
       const match = expect.stringMatching(/[0-9]{4}-[0-9]{2}-[0-9]{2}.*/);
       expect(timestamp).toEqual(match);
     });

--- a/src/__tests__/ReduxWebSocket.test.ts
+++ b/src/__tests__/ReduxWebSocket.test.ts
@@ -296,7 +296,6 @@ describe('ReduxWebSocket', () => {
     });
 
     it('should use a JSON serialized Date if stringTimestamp is true', () => {
-
       reduxWebSocket = new ReduxWebSocket({
         ...options,
         stringTimestamp: true,

--- a/src/__tests__/ReduxWebSocket.test.ts
+++ b/src/__tests__/ReduxWebSocket.test.ts
@@ -295,6 +295,43 @@ describe('ReduxWebSocket', () => {
       expect(sendMock).toHaveBeenCalledWith('{"test":"value"}');
     });
 
+    it('should use a JSON serialized Date if stringTimestamp is true', () => {
+
+      reduxWebSocket = new ReduxWebSocket({
+        ...options,
+        stringTimestamp: true,
+      });
+
+      const connectAction = { type: CONNECT, payload: { url } };
+      reduxWebSocket.connect(store, connectAction);
+
+      const event = addEventListenerMock.mock.calls.find(
+        (call) => call[0] === 'message'
+      );
+      const data = '{ "test": "message" }';
+      const testEvent = { data, origin: 'test origin' };
+
+      event[1](testEvent);
+
+      expect(store.dispatch).toHaveBeenCalledTimes(1);
+      expect(store.dispatch).toHaveBeenCalledWith({
+        type: 'REDUX_WEBSOCKET::MESSAGE',
+        meta: {
+          timestamp: expect.anything(),
+        },
+        payload: {
+          event: testEvent,
+          message: data,
+          origin: 'test origin',
+        },
+      });
+
+      const call = store.dispatch.mock.calls[0][0];
+      const timestamp: string = call.meta.timestamp;
+      const match = expect.stringMatching(/[0-9]{4}-[0-9]{2}-[0-9]{2}.*/);
+      expect(timestamp).toEqual(match);
+    });
+
     it('should send a custom message', () => {
       const action = { type: 'SEND', payload: { url } };
       const pld = { test: 'value', another: 'prop' };

--- a/src/__tests__/ReduxWebSocket.test.ts
+++ b/src/__tests__/ReduxWebSocket.test.ts
@@ -17,6 +17,7 @@ describe('ReduxWebSocket', () => {
   const url = 'ws://fake.com';
   const options = {
     prefix: 'REDUX_WEBSOCKET',
+    string_timestamp: false,
     reconnectInterval: 2000,
     reconnectOnClose: false,
     serializer: JSON.stringify,
@@ -111,10 +112,10 @@ describe('ReduxWebSocket', () => {
 
       /* eslint-disable dot-notation */
       rws['handleBrokenConnection'] = jest.fn();
-      rws['handleClose'](dispatch, 'prefix', event);
+      rws['handleClose'](dispatch, false, 'prefix', event);
       expect(rws['handleBrokenConnection']).not.toHaveBeenCalled();
       rws['hasOpened'] = true;
-      rws['handleClose'](dispatch, 'prefix', event);
+      rws['handleClose'](dispatch, false, 'prefix', event);
       expect(rws['handleBrokenConnection']).toHaveBeenCalledTimes(1);
       expect(rws['handleBrokenConnection']).toHaveBeenCalledWith(dispatch);
       /* eslint-enable dot-notation */
@@ -171,11 +172,11 @@ describe('ReduxWebSocket', () => {
 
         /* eslint-disable dot-notation */
         reduxWebSocket['handleBrokenConnection'] = jest.fn();
-        reduxWebSocket['handleError'](dispatch, 'prefix');
+        reduxWebSocket['handleError'](dispatch, false, 'prefix');
         expect(reduxWebSocket['handleBrokenConnection']).not.toHaveBeenCalled();
 
         reduxWebSocket['hasOpened'] = true;
-        reduxWebSocket['handleError'](dispatch, 'prefix');
+        reduxWebSocket['handleError'](dispatch, false, 'prefix');
         expect(reduxWebSocket['handleBrokenConnection']).toHaveBeenCalledTimes(
           1
         );

--- a/src/__tests__/ReduxWebSocket.test.ts
+++ b/src/__tests__/ReduxWebSocket.test.ts
@@ -17,7 +17,7 @@ describe('ReduxWebSocket', () => {
   const url = 'ws://fake.com';
   const options = {
     prefix: 'REDUX_WEBSOCKET',
-    string_timestamp: false,
+    stringTimestamp: false,
     reconnectInterval: 2000,
     reconnectOnClose: false,
     serializer: JSON.stringify,

--- a/src/__tests__/actions.test.ts
+++ b/src/__tests__/actions.test.ts
@@ -3,13 +3,14 @@ import { isFSA, isError } from 'flux-standard-action';
 import * as actions from '../actions';
 import * as actionTypes from '../actionTypes';
 
+const STRING_TIMESTAMP = false;
 const PREFIX = 'ACTION_PREFIX';
 
 describe('actions', () => {
   describe('user dispatched', () => {
     describe('connect', () => {
       it('should return the correct action with a default prefix', () => {
-        const act = actions.connect('fake url');
+        const act = actions.connect('fake url', STRING_TIMESTAMP);
 
         expect(isFSA(act)).toBe(true);
         expect(act).toEqual({
@@ -22,7 +23,7 @@ describe('actions', () => {
       });
 
       it('should return the correct action with user prefix', () => {
-        const act = actions.connect('fake url', PREFIX);
+        const act = actions.connect('fake url', STRING_TIMESTAMP, PREFIX);
 
         expect(isFSA(act)).toBe(true);
         expect(act).toEqual({
@@ -35,7 +36,7 @@ describe('actions', () => {
       });
 
       it('should return the correct action with protocols', () => {
-        const act = actions.connect('fake url', ['protocol']);
+        const act = actions.connect('fake url', STRING_TIMESTAMP, ['protocol']);
 
         expect(isFSA(act)).toBe(true);
         expect(act).toEqual({
@@ -49,7 +50,7 @@ describe('actions', () => {
       });
 
       it('should return the correct action with protocols and a user prefix', () => {
-        const act = actions.connect('fake url', ['protocol'], PREFIX);
+        const act = actions.connect('fake url', STRING_TIMESTAMP, ['protocol'], PREFIX);
 
         expect(isFSA(act)).toBe(true);
         expect(act).toEqual({
@@ -65,7 +66,7 @@ describe('actions', () => {
 
     describe('disconnect', () => {
       it('should return the correct action with a default prefix', () => {
-        const act = actions.disconnect();
+        const act = actions.disconnect(STRING_TIMESTAMP);
 
         expect(isFSA(act)).toBe(true);
         expect(act).toEqual({
@@ -75,7 +76,7 @@ describe('actions', () => {
       });
 
       it('should return the correct action with user prefix', () => {
-        const act = actions.disconnect(PREFIX);
+        const act = actions.disconnect(STRING_TIMESTAMP, PREFIX);
 
         expect(isFSA(act)).toBe(true);
         expect(act).toEqual({
@@ -87,7 +88,7 @@ describe('actions', () => {
 
     describe('send', () => {
       it('should return the correct action with a default prefix', () => {
-        const act = actions.send({ test: 'value' });
+        const act = actions.send({ test: 'value' }, STRING_TIMESTAMP);
 
         expect(isFSA(act)).toBe(true);
         expect(act).toEqual({
@@ -100,7 +101,7 @@ describe('actions', () => {
       });
 
       it('should return the correct action with user prefix', () => {
-        const act = actions.send({ test: 'value' }, PREFIX);
+        const act = actions.send({ test: 'value' }, STRING_TIMESTAMP, PREFIX);
 
         expect(isFSA(act)).toBe(true);
         expect(act).toEqual({
@@ -117,7 +118,7 @@ describe('actions', () => {
   describe('library dispatched', () => {
     describe('beginReconnect', () => {
       it('should return the correct action', () => {
-        const act = actions.beginReconnect(PREFIX);
+        const act = actions.beginReconnect(STRING_TIMESTAMP, PREFIX);
 
         expect(isFSA(act)).toBe(true);
         expect(act).toEqual({
@@ -129,7 +130,7 @@ describe('actions', () => {
 
     describe('reconnectAttempt', () => {
       it('should return the correct action', () => {
-        const act = actions.reconnectAttempt(1, PREFIX);
+        const act = actions.reconnectAttempt(1, STRING_TIMESTAMP, PREFIX);
 
         expect(isFSA(act)).toBe(true);
         expect(act).toEqual({
@@ -144,7 +145,7 @@ describe('actions', () => {
 
     describe('reconnected', () => {
       it('should return the correct action', () => {
-        const act = actions.reconnected(PREFIX);
+        const act = actions.reconnected(STRING_TIMESTAMP, PREFIX);
 
         expect(isFSA(act)).toBe(true);
         expect(act).toEqual({
@@ -157,7 +158,7 @@ describe('actions', () => {
     describe('closed', () => {
       it('should return the correct action', () => {
         const event = new Event('');
-        const act = actions.closed(event, PREFIX);
+        const act = actions.closed(event, STRING_TIMESTAMP, PREFIX);
 
         expect(isFSA(act)).toBe(true);
         expect(act).toEqual({
@@ -171,7 +172,7 @@ describe('actions', () => {
     describe('message', () => {
       it('should return the correct action', () => {
         const event = new MessageEvent('');
-        const act = actions.message(event, PREFIX);
+        const act = actions.message(event, STRING_TIMESTAMP, PREFIX);
 
         expect(isFSA(act)).toBe(true);
         expect(act).toEqual({
@@ -189,7 +190,7 @@ describe('actions', () => {
     describe('open', () => {
       it('should return the correct action', () => {
         const event = new Event('');
-        const act = actions.open(event, PREFIX);
+        const act = actions.open(event, STRING_TIMESTAMP, PREFIX);
 
         expect(isFSA(act)).toBe(true);
         expect(act).toEqual({
@@ -202,7 +203,7 @@ describe('actions', () => {
 
     describe('broken', () => {
       it('should return the correct action', () => {
-        const act = actions.broken(PREFIX);
+        const act = actions.broken(STRING_TIMESTAMP, PREFIX);
 
         expect(isFSA(act)).toBe(true);
         expect(act).toEqual({
@@ -216,7 +217,7 @@ describe('actions', () => {
       it('should return the correct action with a test action', () => {
         const err = new Error('test');
         const originalAction = { type: 'SEND' as 'SEND', payload: null };
-        const act = actions.error(originalAction, err, PREFIX);
+        const act = actions.error(originalAction, err, STRING_TIMESTAMP, PREFIX);
 
         expect(isFSA(act)).toBe(true);
         expect(isError(act)).toBe(true);
@@ -235,7 +236,7 @@ describe('actions', () => {
 
       it('should return the correct action with a null action', () => {
         const err = new Error('test');
-        const act = actions.error(null, err, PREFIX);
+        const act = actions.error(null, err, STRING_TIMESTAMP, PREFIX);
 
         expect(isFSA(act)).toBe(true);
         expect(isError(act)).toBe(true);

--- a/src/__tests__/actions.test.ts
+++ b/src/__tests__/actions.test.ts
@@ -50,7 +50,12 @@ describe('actions', () => {
       });
 
       it('should return the correct action with protocols and a user prefix', () => {
-        const act = actions.connect('fake url', STRING_TIMESTAMP, ['protocol'], PREFIX);
+        const act = actions.connect(
+          'fake url',
+          STRING_TIMESTAMP,
+          ['protocol'],
+          PREFIX
+        );
 
         expect(isFSA(act)).toBe(true);
         expect(act).toEqual({
@@ -217,7 +222,12 @@ describe('actions', () => {
       it('should return the correct action with a test action', () => {
         const err = new Error('test');
         const originalAction = { type: 'SEND' as 'SEND', payload: null };
-        const act = actions.error(originalAction, err, STRING_TIMESTAMP, PREFIX);
+        const act = actions.error(
+          originalAction,
+          err,
+          STRING_TIMESTAMP,
+          PREFIX
+        );
 
         expect(isFSA(act)).toBe(true);
         expect(isError(act)).toBe(true);

--- a/src/__tests__/createMiddleware.test.ts
+++ b/src/__tests__/createMiddleware.test.ts
@@ -83,7 +83,11 @@ describe('middleware', () => {
 
   it('can create multiple instances of ReduxWebSocket', () => {
     middleware({ prefix: 'ONE', stringTimestamp: false });
-    middleware({ prefix: 'TWO', stringTimestamp: false, reconnectOnClose: true });
+    middleware({
+      prefix: 'TWO',
+      stringTimestamp: false,
+      reconnectOnClose: true,
+    });
 
     expect(ReduxWebSocketMock).toHaveBeenCalledTimes(2);
     expect(ReduxWebSocketMock).toHaveBeenCalledWith({

--- a/src/__tests__/createMiddleware.test.ts
+++ b/src/__tests__/createMiddleware.test.ts
@@ -62,7 +62,7 @@ describe('middleware', () => {
 
     expect(ReduxWebSocketMock).toHaveBeenCalledWith({
       prefix: 'REDUX_WEBSOCKET',
-      string_timestamp: false,
+      stringTimestamp: false,
       reconnectInterval: 2000,
       reconnectOnClose: false,
       serializer: JSON.stringify,
@@ -70,11 +70,11 @@ describe('middleware', () => {
   });
 
   it('passes custom options to the ReduxWebSocket constructor', () => {
-    middleware({ prefix: 'CUSTOM', string_timestamp: false });
+    middleware({ prefix: 'CUSTOM', stringTimestamp: false });
 
     expect(ReduxWebSocketMock).toHaveBeenCalledWith({
       prefix: 'CUSTOM',
-      string_timestamp: false,
+      stringTimestamp: false,
       reconnectInterval: 2000,
       reconnectOnClose: false,
       serializer: JSON.stringify,
@@ -82,20 +82,20 @@ describe('middleware', () => {
   });
 
   it('can create multiple instances of ReduxWebSocket', () => {
-    middleware({ prefix: 'ONE', string_timestamp: false });
-    middleware({ prefix: 'TWO', string_timestamp: false, reconnectOnClose: true });
+    middleware({ prefix: 'ONE', stringTimestamp: false });
+    middleware({ prefix: 'TWO', stringTimestamp: false, reconnectOnClose: true });
 
     expect(ReduxWebSocketMock).toHaveBeenCalledTimes(2);
     expect(ReduxWebSocketMock).toHaveBeenCalledWith({
       prefix: 'ONE',
-      string_timestamp: false,
+      stringTimestamp: false,
       reconnectInterval: 2000,
       reconnectOnClose: false,
       serializer: JSON.stringify,
     });
     expect(ReduxWebSocketMock).toHaveBeenCalledWith({
       prefix: 'TWO',
-      string_timestamp: false,
+      stringTimestamp: false,
       reconnectInterval: 2000,
       reconnectOnClose: true,
       serializer: JSON.stringify,

--- a/src/__tests__/createMiddleware.test.ts
+++ b/src/__tests__/createMiddleware.test.ts
@@ -62,6 +62,7 @@ describe('middleware', () => {
 
     expect(ReduxWebSocketMock).toHaveBeenCalledWith({
       prefix: 'REDUX_WEBSOCKET',
+      string_timestamp: false,
       reconnectInterval: 2000,
       reconnectOnClose: false,
       serializer: JSON.stringify,
@@ -69,10 +70,11 @@ describe('middleware', () => {
   });
 
   it('passes custom options to the ReduxWebSocket constructor', () => {
-    middleware({ prefix: 'CUSTOM' });
+    middleware({ prefix: 'CUSTOM', string_timestamp: false });
 
     expect(ReduxWebSocketMock).toHaveBeenCalledWith({
       prefix: 'CUSTOM',
+      string_timestamp: false,
       reconnectInterval: 2000,
       reconnectOnClose: false,
       serializer: JSON.stringify,
@@ -80,18 +82,20 @@ describe('middleware', () => {
   });
 
   it('can create multiple instances of ReduxWebSocket', () => {
-    middleware({ prefix: 'ONE' });
-    middleware({ prefix: 'TWO', reconnectOnClose: true });
+    middleware({ prefix: 'ONE', string_timestamp: false });
+    middleware({ prefix: 'TWO', string_timestamp: false, reconnectOnClose: true });
 
     expect(ReduxWebSocketMock).toHaveBeenCalledTimes(2);
     expect(ReduxWebSocketMock).toHaveBeenCalledWith({
       prefix: 'ONE',
+      string_timestamp: false,
       reconnectInterval: 2000,
       reconnectOnClose: false,
       serializer: JSON.stringify,
     });
     expect(ReduxWebSocketMock).toHaveBeenCalledWith({
       prefix: 'TWO',
+      string_timestamp: false,
       reconnectInterval: 2000,
       reconnectOnClose: true,
       serializer: JSON.stringify,
@@ -108,7 +112,7 @@ describe('middleware', () => {
       },
     };
 
-    const val = dispatch(actions.connect('ws://example.com'));
+    const val = dispatch(actions.connect('ws://example.com', false));
 
     expect(val).toEqual(dispatchedAction);
     expect(connectMock).toHaveBeenCalledTimes(1);
@@ -122,7 +126,7 @@ describe('middleware', () => {
       meta: { timestamp: expect.any(Date) },
     };
 
-    const val = dispatch(actions.disconnect());
+    const val = dispatch(actions.disconnect(false));
 
     expect(val).toEqual(dispatchedAction);
     expect(disconnectMock).toHaveBeenCalledTimes(1);
@@ -139,7 +143,7 @@ describe('middleware', () => {
       },
     };
 
-    const val = dispatch(actions.send({ test: 'message' }));
+    const val = dispatch(actions.send({ test: 'message' }, false));
 
     expect(val).toEqual(dispatchedAction);
     expect(sendMock).toHaveBeenCalledTimes(1);
@@ -167,7 +171,7 @@ describe('middleware', () => {
     });
 
     const { dispatch } = mockStore();
-    const result = dispatch(actions.send({ test: 'message' }));
+    const result = dispatch(actions.send({ test: 'message' }, false));
     const expectedResult = {
       type: 'REDUX_WEBSOCKET::SEND',
       meta: {

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -44,12 +44,12 @@ const isProtocols = (args: ConnectRestArgs): args is WithProtocols =>
  */
 function buildAction<T>(
   actionType: string,
-  string_timestamp: boolean,
+  stringTimestamp: boolean,
   payload?: T,
   meta?: any
 ): BuiltAction<T> {
   var timestamp: Date | string = new Date();
-  if (string_timestamp) {
+  if (stringTimestamp) {
     timestamp = timestamp.toJSON();
   }
   const base = {
@@ -69,7 +69,7 @@ function buildAction<T>(
 // prefixed.
 export const connect = (
   url: string,
-  string_timestamp: boolean,
+  stringTimestamp: boolean,
   ...args: ConnectRestArgs
 ) => {
   let prefix: string | undefined;
@@ -87,7 +87,7 @@ export const connect = (
 
   return buildAction(
     `${prefix || DEFAULT_PREFIX}::${WEBSOCKET_CONNECT}`,
-    string_timestamp,
+    stringTimestamp,
     {
       url,
       protocols,
@@ -95,17 +95,17 @@ export const connect = (
   );
 };
 export const disconnect = (...args: WithStringDateAndPrefix) => {
-  const [string_timestamp, prefix] = args;
+  const [stringTimestamp, prefix] = args;
   return buildAction(
     `${prefix || DEFAULT_PREFIX}::${WEBSOCKET_DISCONNECT}`,
-    string_timestamp
+    stringTimestamp
   );
 };
 export const send = (msg: any, ...args: WithStringDateAndPrefix) => {
-  const [string_timestamp, prefix] = args;
+  const [stringTimestamp, prefix] = args;
   return buildAction(
     `${prefix || DEFAULT_PREFIX}::${WEBSOCKET_SEND}`,
-    string_timestamp,
+    stringTimestamp,
     msg
   );
 };
@@ -114,45 +114,45 @@ export const send = (msg: any, ...args: WithStringDateAndPrefix) => {
 // take a prefix. The default prefix should be used unless a user has created
 // this middleware with the prefix option set.
 export const beginReconnect = (...args: WithStringDateAndPrefix) => {
-  const [string_timestamp, prefix] = args;
+  const [stringTimestamp, prefix] = args;
   return buildAction(
     `${prefix}::${WEBSOCKET_BEGIN_RECONNECT}`,
-    string_timestamp
+    stringTimestamp
   );
 };
 export const reconnectAttempt = (
   count: number,
   ...args: WithStringDateAndPrefix
 ) => {
-  const [string_timestamp, prefix] = args;
+  const [stringTimestamp, prefix] = args;
   return buildAction(
     `${prefix}::${WEBSOCKET_RECONNECT_ATTEMPT}`,
-    string_timestamp,
+    stringTimestamp,
     { count }
   );
 };
 export const reconnected = (...args: WithStringDateAndPrefix) => {
-  const [string_timestamp, prefix] = args;
-  return buildAction(`${prefix}::${WEBSOCKET_RECONNECTED}`, string_timestamp);
+  const [stringTimestamp, prefix] = args;
+  return buildAction(`${prefix}::${WEBSOCKET_RECONNECTED}`, stringTimestamp);
 };
 export const open = (event: Event, ...args: WithStringDateAndPrefix) => {
-  const [string_timestamp, prefix] = args;
-  return buildAction(`${prefix}::${WEBSOCKET_OPEN}`, string_timestamp, event);
+  const [stringTimestamp, prefix] = args;
+  return buildAction(`${prefix}::${WEBSOCKET_OPEN}`, stringTimestamp, event);
 };
 export const broken = (...args: WithStringDateAndPrefix) => {
-  const [string_timestamp, prefix] = args;
-  return buildAction(`${prefix}::${WEBSOCKET_BROKEN}`, string_timestamp);
+  const [stringTimestamp, prefix] = args;
+  return buildAction(`${prefix}::${WEBSOCKET_BROKEN}`, stringTimestamp);
 };
 export const closed = (event: Event, ...args: WithStringDateAndPrefix) => {
-  const [string_timestamp, prefix] = args;
-  return buildAction(`${prefix}::${WEBSOCKET_CLOSED}`, string_timestamp, event);
+  const [stringTimestamp, prefix] = args;
+  return buildAction(`${prefix}::${WEBSOCKET_CLOSED}`, stringTimestamp, event);
 };
 export const message = (
   event: MessageEvent,
   ...args: WithStringDateAndPrefix
 ) => {
-  const [string_timestamp, prefix] = args;
-  return buildAction(`${prefix}::${WEBSOCKET_MESSAGE}`, string_timestamp, {
+  const [stringTimestamp, prefix] = args;
+  return buildAction(`${prefix}::${WEBSOCKET_MESSAGE}`, stringTimestamp, {
     event,
     message: event.data,
     origin: event.origin,
@@ -163,8 +163,8 @@ export const error = (
   err: Error,
   ...args: WithStringDateAndPrefix
 ) => {
-  const [string_timestamp, prefix] = args;
-  return buildAction(`${prefix}::${WEBSOCKET_ERROR}`, string_timestamp, err, {
+  const [stringTimestamp, prefix] = args;
+  return buildAction(`${prefix}::${WEBSOCKET_ERROR}`, stringTimestamp, err, {
     message: err.message,
     name: err.name,
     originalAction,

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -48,14 +48,14 @@ function buildAction<T>(
   payload?: T,
   meta?: any
 ): BuiltAction<T> {
-  var timestamp: Date | string = new Date();
+  let timestamp: Date | string = new Date();
   if (stringTimestamp) {
     timestamp = timestamp.toJSON();
   }
   const base = {
     type: actionType,
     meta: {
-      timestamp: timestamp,
+      timestamp,
       ...meta,
     },
     // Mixin the `error` key if the payload is an Error.

--- a/src/createMiddleware.ts
+++ b/src/createMiddleware.ts
@@ -14,6 +14,7 @@ const defaultOptions = {
   reconnectOnClose: false,
   prefix: actionTypes.DEFAULT_PREFIX,
   serializer: JSON.stringify,
+  string_timestamp: false,
 };
 
 /**
@@ -25,7 +26,7 @@ const defaultOptions = {
  */
 export default (rawOptions?: Options): Middleware => {
   const options = { ...defaultOptions, ...rawOptions };
-  const { prefix } = options;
+  const { string_timestamp, prefix } = options;
   const actionPrefixExp = RegExp(`^${prefix}::`);
 
   // Create a new redux websocket instance.
@@ -52,7 +53,7 @@ export default (rawOptions?: Options): Middleware => {
         try {
           handler(store, action);
         } catch (err) {
-          dispatch(error(action, err, prefix));
+          dispatch(error(action, err, string_timestamp, prefix));
         }
       }
     }

--- a/src/createMiddleware.ts
+++ b/src/createMiddleware.ts
@@ -14,7 +14,7 @@ const defaultOptions = {
   reconnectOnClose: false,
   prefix: actionTypes.DEFAULT_PREFIX,
   serializer: JSON.stringify,
-  string_timestamp: false,
+  stringTimestamp: false,
 };
 
 /**
@@ -26,7 +26,7 @@ const defaultOptions = {
  */
 export default (rawOptions?: Options): Middleware => {
   const options = { ...defaultOptions, ...rawOptions };
-  const { string_timestamp, prefix } = options;
+  const { stringTimestamp, prefix } = options;
   const actionPrefixExp = RegExp(`^${prefix}::`);
 
   // Create a new redux websocket instance.
@@ -53,7 +53,7 @@ export default (rawOptions?: Options): Middleware => {
         try {
           handler(store, action);
         } catch (err) {
-          dispatch(error(action, err, string_timestamp, prefix));
+          dispatch(error(action, err, stringTimestamp, prefix));
         }
       }
     }

--- a/src/types.ts
+++ b/src/types.ts
@@ -28,12 +28,12 @@ type Action =
   | { type: typeof WEBSOCKET_SEND; payload: any };
 
 type Options = {
+  stringTimestamp: boolean;
   prefix?: string;
   reconnectInterval?: number;
   reconnectOnClose?: boolean;
   onOpen?: (s: WebSocket) => void;
   serializer?: Serializer;
-  string_timestamp: boolean;
 };
 
 // Huh? https://github.com/babel/babel/issues/6065#issuecomment-453901877

--- a/src/types.ts
+++ b/src/types.ts
@@ -33,6 +33,7 @@ type Options = {
   reconnectOnClose?: boolean;
   onOpen?: (s: WebSocket) => void;
   serializer?: Serializer;
+  string_timestamp: boolean;
 };
 
 // Huh? https://github.com/babel/babel/issues/6065#issuecomment-453901877


### PR DESCRIPTION
Currently when actions are created by this middleware, it causes warnings like this:

```
A non-serializable value was detected in an action, in the path: `meta.timestamp`. Value:
Date Sat Jun 27 2020 07:10:14 GMT-0700 (Pacific Daylight Time)

Take a look at the logic that dispatched this action:
Object { type: "REDUX_WEBSOCKET::OPEN", meta: {…}, payload: open }

(See https://redux.js.org/faq/actions#why-should-type-be-a-string-or-at-least-serializable-why-should-my-action-types-be-constants)
(To allow non-serializable values see: https://redux-toolkit.js.org/usage/usage-guide#working-with-non-serializable-data) react_devtools_backend.js:6:7472
```

This is because `meta.timestamp` is a `Date`, which is not serializable.

The redux docs don't explicitly ban this behaviour, but they do discourage it, and I figure a framework should probably have an option to conform to recommendations.

This PR adds the ability to choose whether to use `Date` or a string JSON representation of this date with the `stringTimestamp` option. By default it still uses `Date`, so as to not break existing users who might depend on this.
