### PR TITLE
Fix "window not defined" error on SSR applications

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -9,6 +9,7 @@ module.exports = {
     path: path.resolve(__dirname, 'dist'),
     filename: 'index.js',
     libraryTarget: 'umd',
+    globalObject: 'this',
   },
   resolve: {
     extensions: ['.ts', '.tsx', '.js', '.json'],


### PR DESCRIPTION
The window object is not readable on Nextjs and other server-side rendered application. 

This change uses `this` as the global object instead of `window`. Details of this fix could be found here: https://github.com/webpack/webpack/issues/6642#issuecomment-371087342